### PR TITLE
docs: streamline AGENTS and README; add conventions, contributing, and test helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,135 +1,23 @@
 # AGENTS.md — AI Agent Instructions for `code-excerpter`
 
-This file contains instructions for AI coding agents (GitHub Copilot, OpenAI
-Codex, Claude, etc.) working on this repository. It is agent-agnostic.
+Instructions for AI coding agents (GitHub Copilot, OpenAI Codex, Claude, and
+similar) working on this repository. Agent-agnostic. When adding guidance,
+extend `docs/` and link from here; keep this file a short index (see
+[docs/conventions.md](docs/conventions.md#ai-guidance)).
 
-See the [`docs/`](docs/) directory for deeper context on architecture, scope,
-and the porting plan.
+**Project:** `code-excerpter` is a TypeScript port of the Dart excerpter tooling
+used for site documentation. Start with [README.md](README.md) for the public
+overview, installation, and clone workflow.
 
----
+**Documentation:**
 
-## Project Overview
-
-`code-excerpter` is a TypeScript port of the Dart excerpter tooling used by
-[dart-lang/site-www](https://github.com/dart-lang/site-www). It is a
-line-based tool for extracting and injecting code excerpts into documentation.
-
-**One-line description:** A line-based tool for extracting and injecting code
-excerpts into documentation.
-
-### Lineage
-
-The tool has its origins in three Dart repositories:
-
-| Repo | Role |
-|---|---|
-| [`chalin/code_excerpter`](https://github.com/chalin/code_excerpter) | Original Dart extraction library — comprehensive tests, `Excerpter` + `Directive` classes |
-| [`chalin/code_excerpt_updater`](https://github.com/chalin/code_excerpt_updater) | Original Dart updater CLI — full `<?code-excerpt?>` syntax, README is the spec |
-| [`dart-lang/site-shared` (`pkgs/excerpter`)](https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter) | Simplified Dart rewrite combining both, currently used in production |
-
----
-
-## Architecture Overview
-
-The module plan follows a layered pipeline:
-
-| Module | Phase | Description |
-|---|---|---|
-| `src/directive.ts` | 1a | Parse `#docregion`/`#enddocregion` directives from source lines |
-| `src/extract.ts` | 1b | Extract named code regions from source file content |
-| `src/transform.ts` | 2 | Transform pipeline: skip, take, from, to, remove, retain, replace, indent |
-| `src/inject.ts` | 3 | Parse `<?code-excerpt?>` instructions in markdown, orchestrate extraction + transforms |
-| `src/update.ts` | 4 | Walk directory trees, find markdown files, run updater on each |
-| `src/index.ts` | — | Public API exports |
-| `src/cli.ts` | 4 | CLI entry point (commander) |
-
-### Data Flow
-
-```
-source files
-  → directive parsing  (src/directive.ts)
-  → region extraction  (src/extract.ts)
-  → transform pipeline (src/transform.ts)
-  → markdown injection (src/inject.ts)
-  → file update        (src/update.ts)
-```
-
-See [`docs/architecture.md`](docs/architecture.md) for the full module-by-module
-analysis including Dart-to-TypeScript mapping notes.
-
----
-
-## Coding Conventions
-
-- **Module system**: ESM throughout. Use `import`/`export`, never `require()`.
-- **TypeScript**: Strict mode enabled (`"strict": true` in `tsconfig.json`).
-- **Built-in imports**: Always use the `node:` prefix (e.g., `node:fs/promises`,
-  `node:path`, `node:url`).
-- **Async I/O**: Prefer `node:fs/promises` for all file operations.
-- **Naming**: Use camelCase for variables/functions, PascalCase for classes and
-  types/interfaces.
-- **Formatting**: 2-space indentation, 100-character line width (enforced by
-  Biome).
-- **No default exports**: Use named exports everywhere.
-
----
-
-## How to Build, Test, and Lint
-
-```sh
-# Install dependencies
-npm install
-
-# Build (outputs to dist/)
-npm run build
-
-# Run tests
-npm test
-
-# Watch mode for tests
-npm run test:watch
-
-# Lint and format check
-npm run lint
-
-# Lint and auto-fix
-npm run lint:fix
-```
-
----
-
-## Key Design Notes
-
-### `Directive` class (`src/directive.ts`)
-
-- Ported from `chalin/code_excerpter`
-- Uses comment-syntax-aware regex: HTML (`-->`), CSS (`*/`), and plain
-  line-comment stripping
-- Returns a structured object with a `issues` list (warnings vs. hard errors)
-- Handles comma-separated region names, duplicate detection, and deprecated
-  unquoted default region names
-
-### Transform pipeline (`src/transform.ts`)
-
-- All transforms are pure functions: `(lines: string[]) => string[]`
-- Processing order matters — see [`docs/spec.md`](docs/spec.md) for the
-  defined order
-- `BackReferenceReplaceTransform` already targets JS regex semantics (uses
-  `$1`, `$2`, etc.)
-
-### CLI (`src/cli.ts`)
-
-- Uses `commander` for argument parsing
-- Entry point in `package.json` `bin` field: `code-excerpter`
-- The `prepare` script runs `tsup` so `npm install github:chalin/code-excerpter`
-  triggers a build automatically
-
----
-
-## References
-
-- [`docs/plan.md`](docs/plan.md) — Phased porting plan with progress checkboxes
-- [`docs/architecture.md`](docs/architecture.md) — Module mapping, Dart→TS porting notes
-- [`docs/tooling.md`](docs/tooling.md) — Tooling decisions with rationale
-- [`docs/scope.md`](docs/scope.md) — Feature scoping for v1
-- [`docs/spec.md`](docs/spec.md) — `<?code-excerpt?>` instruction syntax specification
+- [docs/architecture.md](docs/architecture.md) — Module map, data flow, Dart
+  repository lineage, Dart→TypeScript porting notes
+- [docs/spec.md](docs/spec.md) — `<?code-excerpt?>` instruction syntax and
+  transform order
+- [docs/plan.md](docs/plan.md) — Phased porting plan with progress checkboxes
+- [docs/scope.md](docs/scope.md) — Feature scoping for v1
+- [docs/tooling.md](docs/tooling.md) — Tooling stack, rationale, and how npm
+  scripts fit together (canonical script list: `package.json` → `scripts`)
+- [docs/conventions.md](docs/conventions.md) — Code style, Vitest testing style,
+  documentation DRY rules, and how to extend AGENTS vs `docs/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thanks for helping improve `code-excerpter`.
+
+- **Clone, install, and npm scripts:** see [README.md](README.md) (especially
+  **Development** and its links into `docs/`).
+- **Code style, tests, documentation, and AI-facing notes:** see
+  [docs/conventions.md](docs/conventions.md).
+
+Issues and pull requests: [github.com/chalin/code-excerpter](https://github.com/chalin/code-excerpter).

--- a/README.md
+++ b/README.md
@@ -10,15 +10,8 @@ A line-based tool for extracting and injecting code excerpts into documentation.
 regions, and updates markdown files containing `<?code-excerpt?>` processing
 instructions.
 
-The tool draws from three original Dart repositories:
-
-- **[chalin/code_excerpter](https://github.com/chalin/code_excerpter)** — the
-  original Dart extraction library with comprehensive tests
-- **[chalin/code_excerpt_updater](https://github.com/chalin/code_excerpt_updater)** —
-  the original Dart updater CLI with full `<?code-excerpt?>` syntax
-- **[dart-lang/site-shared (`pkgs/excerpter`)](https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter)** —
-  a simplified Dart rewrite combining both tools, currently used by
-  `dart-lang/site-www`
+Lineage and upstream Dart repositories are summarized in
+[docs/architecture.md](docs/architecture.md#relationship-to-the-dart-repositories).
 
 The `<?code-excerpt?>` instruction syntax is documented in
 [docs/spec.md](docs/spec.md).
@@ -56,31 +49,11 @@ cd code-excerpter
 npm install
 ```
 
-### Build
-
-```sh
-npm run build
-```
-
-### Test
-
-```sh
-npm test
-```
-
-### Lint
-
-```sh
-npm run lint
-```
-
-To auto-fix lint issues:
-
-```sh
-npm run lint:fix
-```
+For more details, see
+[docs/tooling.md](docs/tooling.md#npm-scripts-and-dependencies). Conventions
+(code, docs, and AI guidance): [docs/conventions.md](docs/conventions.md).
+Contributor orientation: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,11 +7,15 @@ its relationship to the original Dart repositories, and key porting decisions.
 
 ## Relationship to the Dart Repositories
 
-| Dart repo | Role in this port |
-|---|---|
-| [`chalin/code_excerpter`](https://github.com/chalin/code_excerpter) | Source for `directive.ts` and `extract.ts`: `Directive` class + `Excerpter` class + test suite |
-| [`chalin/code_excerpt_updater`](https://github.com/chalin/code_excerpt_updater) | Source for `inject.ts`, `update.ts`, `cli.ts`: `<?code-excerpt?>` syntax + updater logic. README is the canonical spec. |
-| [`dart-lang/site-shared` (`pkgs/excerpter`)](https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter) | Reference implementation combining both of the above. Implementation is the primary guide for this port. |
+Each part of this port maps to upstream Dart work in one of these repositories:
+
+- [`chalin/code_excerpter`][]: source for `directive.ts` and `extract.ts`
+  (`Directive` class, `Excerpter` class, and the extraction test suite).
+- [`chalin/code_excerpt_updater`][]: source for `inject.ts`, `update.ts`, and
+  `cli.ts` (`<?code-excerpt?>` syntax and updater logic; its README is the
+  canonical spec).
+- [`dart-lang/site-shared`][] (`pkgs/excerpter`): reference implementation that
+  combines both of the above; its code is the primary guide for this port.
 
 ---
 
@@ -54,16 +58,16 @@ All transforms are pure functions: `(lines: string[]) => string[]`.
 
 Supported transforms (in processing order):
 
-| Transform | Description |
-|---|---|
-| `skip` | Skip the first N lines |
-| `take` | Keep only the first N lines |
-| `from` | Start from the first line matching a pattern |
-| `to` | Stop at (and exclude) the first line matching a pattern |
-| `remove` | Remove all lines matching a pattern |
-| `retain` | Keep only lines matching a pattern |
-| `replace` | Replace pattern matches with a substitution string |
-| `indent-by` | Prepend N spaces to every line |
+| Transform   | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `skip`      | Skip the first N lines                                  |
+| `take`      | Keep only the first N lines                             |
+| `from`      | Start from the first line matching a pattern            |
+| `to`        | Stop at (and exclude) the first line matching a pattern |
+| `remove`    | Remove all lines matching a pattern                     |
+| `retain`    | Keep only lines matching a pattern                      |
+| `replace`   | Replace pattern matches with a substitution string      |
+| `indent-by` | Prepend N spaces to every line                          |
 
 Key porting note: `BackReferenceReplaceTransform` in Dart already targets JS
 regex back-reference semantics (`$1`, `$2`), so this is a straightforward port.
@@ -137,3 +141,7 @@ src/update.ts — walk filesystem, update files, write changes
 
 4. **`node:` prefix**: All Node.js built-in imports use the `node:` prefix to
    make the import origin explicit and avoid any potential name conflicts.
+
+[`chalin/code_excerpter`]: https://github.com/chalin/code_excerpter
+[`chalin/code_excerpt_updater`]: https://github.com/chalin/code_excerpt_updater
+[`dart-lang/site-shared`]: https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,59 @@
+# Conventions
+
+Project conventions for code, documentation, and tests.
+
+## Code
+
+- Keep code (including tests) very [DRY][].
+
+### TypeScript / Node.js
+
+- **Module system**: ESM throughout. Use `import`/`export`, never `require()`.
+- **TypeScript**: Strict mode enabled (`"strict": true` in `tsconfig.json`).
+- **Built-in imports**: Always use the `node:` prefix (e.g., `node:fs/promises`,
+  `node:path`, `node:url`).
+- **Async I/O**: Prefer `node:fs/promises` for all file operations.
+- **Naming**: Use camelCase for variables/functions, PascalCase for classes and
+  types/interfaces.
+- **Formatting**: 2-space indentation, 100-character line width (enforced by
+  Biome).
+- **No default exports**: Use named exports everywhere in `src/` and `test/`.
+  Bundler or test **config files** may use `export default` when the tool API
+  requires it (for example `tsup.config.ts`, `vitest.config.ts`).
+
+### Tests (Vitest)
+
+This section offers guidance on writing tests for the project.
+
+When a test fails, the output should make it obvious **what** was checked and
+show a **clear diff** between actual and expected, without long hand-written
+messages. (Same goals as described for Node’s `assert` in the OpenTelemetry
+site’s [testing notes][otel-testing]; the ideas map directly to Vitest.)
+
+1. Prefer **strict, diff-friendly matchers** (for example `expect(x).toBe(y)`,
+   `toEqual` / `toStrictEqual` for objects) instead of checks that only collapse
+   to “expected true, got false.”
+2. Use a **short message** on `expect` when it names the field or case under test
+   (for example issue kind, region name), not a paragraph of prose.
+3. When intent is “matches this pattern,” prefer **`toMatch`** (or an
+   equivalent) over a chain of vague `ok` / `includes` logic.
+4. **DRY test code:** put repeated assertions or small test-only helpers in a
+   module **colocated with the tests** that use them (for example under
+   `test/`) and import them—do not copy-paste the same check across files unless
+   it truly belongs inline once.
+
+## Documentation
+
+This includes project README, AGENTS, and other docs, as well as code comments.
+
+- Keep docs very [DRY][] and terse. Avoid unnecessary verbosity and detail.
+- Use simple, multilingual prose. Avoid idiomatic English.
+
+### AI guidance
+
+- Keep **[AGENTS.md](../AGENTS.md)** minimal: add depth in the appropriate
+  `docs/*.md` file and link from AGENTS; do not duplicate architecture tables,
+  data-flow diagrams, or `package.json` script listings here.
+
+[DRY]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
+[otel-testing]: https://github.com/open-telemetry/opentelemetry.io/blob/c48fe2d260c56d6f60916db3b804e67372b3df8d/content/en/site/testing/_index.md

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -52,8 +52,8 @@ This includes project README, AGENTS, and other docs, as well as code comments.
 ### AI guidance
 
 - Keep **[AGENTS.md](../AGENTS.md)** minimal: add depth in the appropriate
-  `docs/*.md` file and link from AGENTS; do not duplicate architecture tables,
-  data-flow diagrams, or `package.json` script listings here.
+  `docs/*.md` file and link from AGENTS; do not duplicate long architecture or
+  lineage write-ups, data-flow diagrams, or `package.json` script listings here.
 
 [DRY]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
 [otel-testing]: https://github.com/open-telemetry/opentelemetry.io/blob/c48fe2d260c56d6f60916db3b804e67372b3df8d/content/en/site/testing/_index.md

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -8,7 +8,7 @@ This document tracks the phased porting of the Dart excerpter tooling to TypeScr
 
 Parse `#docregion`/`#enddocregion` directives from source lines. Pure string
 logic, no I/O. Port the `Directive` class from
-[`chalin/code_excerpter`](https://github.com/chalin/code_excerpter) with
+[`chalin/code_excerpter`][] with
 comment-syntax-aware regex (HTML `-->`, CSS `*/`).
 
 - [x] Implement `src/directive.ts`
@@ -18,13 +18,13 @@ comment-syntax-aware regex (HTML `-->`, CSS `*/`).
 ## Phase 1b — `extract.ts`
 
 Extract named code regions from source file content. Port the `Excerpter`
-class from [`chalin/code_excerpter`](https://github.com/chalin/code_excerpter).
+class from [`chalin/code_excerpter`][].
 
 - [x] Implement `src/extract.ts`
 - [x] Write `test/extract.test.ts`
 - [x] Port comprehensive test cases from
-  [`chalin/code_excerpter/test/excerpter_test.dart`](https://github.com/chalin/code_excerpter/blob/master/test/excerpter_test.dart)
-  (edge cases, plaster, overlapping regions)
+      [`chalin/code_excerpter/test/excerpter_test.dart`][]
+      (edge cases, plaster, overlapping regions)
 - [x] Update docs as needed
 
 ## Phase 2 — `transform.ts`
@@ -63,3 +63,6 @@ diff output against the Dart tool.
 - [ ] Run against `dart-lang/site-www`
 - [ ] Compare output with the Dart excerpter
 - [ ] Document any discrepancies
+
+[`chalin/code_excerpter`]: https://github.com/chalin/code_excerpter
+[`chalin/code_excerpter/test/excerpter_test.dart`]: https://github.com/chalin/code_excerpter/blob/master/test/excerpter_test.dart

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -62,25 +62,32 @@ syntax).
 
 ## Deferred (post-v1)
 
-| Feature | Reason |
-|---|---|
-| `diff-with` / `diff-u` | Complex output format, low priority for initial port |
-| Angular interpolation escaping | Specific to Angular docs, not general-purpose |
+| Feature                        | Reason                                               |
+| ------------------------------ | ---------------------------------------------------- |
+| `diff-with` / `diff-u`         | Complex output format, low priority for initial port |
+| Angular interpolation escaping | Specific to Angular docs, not general-purpose        |
 
 ---
 
 ## Dropped
 
-| Feature | Reason |
-|---|---|
+| Feature              | Reason                                 |
+| -------------------- | -------------------------------------- |
 | `.jade` file support | Jade/Pug is obsolete; no current users |
 
 ---
 
 ## What to Carry Forward from Each Source Repo
 
-| Source | What we carry forward |
-|---|---|
-| [`chalin/code_excerpter`](https://github.com/chalin/code_excerpter) | Test cases for the `Excerpter` and `Directive` classes (edge cases, plaster, overlapping regions) |
-| [`chalin/code_excerpt_updater`](https://github.com/chalin/code_excerpt_updater) | The `<?code-excerpt?>` syntax specification (README is the canonical spec); updater logic |
-| [`dart-lang/site-shared`](https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter) | Reference implementation — primary guide for this TypeScript port |
+The v1 scope assumes we reuse upstream Dart material as follows:
+
+- [`chalin/code_excerpter`][]: test cases for the `Excerpter` and `Directive`
+  classes (edge cases, plaster, overlapping regions).
+- [`chalin/code_excerpt_updater`][]: the `<?code-excerpt?>` syntax specification
+  (that repo’s README is the canonical spec) and updater logic.
+- [`dart-lang/site-shared`][]: reference implementation and primary guide for
+  this TypeScript port.
+
+[`chalin/code_excerpter`]: https://github.com/chalin/code_excerpter
+[`chalin/code_excerpt_updater`]: https://github.com/chalin/code_excerpt_updater
+[`dart-lang/site-shared`]: https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -34,11 +34,14 @@ Specifies a source file (and optionally a named region) to inject:
 
 **Example:**
 
-```markdown
+````markdown
 <?code-excerpt "lib/main.dart (setup)"?>
+
 ```dart
 // extracted content here
 ```
+````
+
 ```
 
 ### Set instruction
@@ -46,8 +49,10 @@ Specifies a source file (and optionally a named region) to inject:
 Sets a persistent value for the current file, such as `path-base`:
 
 ```
+
 <?code-excerpt path-base="examples/ng/doc"?>
-```
+
+````
 
 A set instruction has no path argument and no following code block. It affects
 all subsequent code fragment instructions in the same file.
@@ -101,7 +106,7 @@ the markdown file requires it (e.g., inside an HTML comment block):
 ```markdown
 // <?code-excerpt "lib/main.dart"?>
 /// <?code-excerpt "lib/main.dart"?>
-```
+````
 
 The tool strips leading `//` or `///` prefixes before parsing the instruction.
 
@@ -127,12 +132,12 @@ commas:
 
 The directive comment prefix depends on the file type:
 
-| File type | Directive form |
-|---|---|
-| Dart, JS, TS, SCSS | `// #docregion` |
-| HTML | `<!-- #docregion -->` |
-| CSS | `/* #docregion */` |
-| YAML | `# #docregion` |
+| File type          | Directive form        |
+| ------------------ | --------------------- |
+| Dart, JS, TS, SCSS | `// #docregion`       |
+| HTML               | `<!-- #docregion -->` |
+| CSS                | `/* #docregion */`    |
+| YAML               | `# #docregion`        |
 
 ### Default region
 
@@ -166,12 +171,12 @@ segments to indicate that content has been omitted.
 
 The default plaster text is language-specific:
 
-| Language | Plaster comment |
-|---|---|
-| Dart, JS, TS | `// ···` |
-| HTML | `<!-- ··· -->` |
-| CSS, SCSS | `/* ··· */` |
-| YAML | `# ···` |
+| Language     | Plaster comment |
+| ------------ | --------------- |
+| Dart, JS, TS | `// ···`        |
+| HTML         | `<!-- ··· -->`  |
+| CSS, SCSS    | `/* ··· */`     |
+| YAML         | `# ···`         |
 
 The plaster can be overridden per-instruction with the `plaster` argument, or
 disabled entirely with `plaster="none"`.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -9,14 +9,14 @@ rationale for each decision.
 
 Semver pins live in **`package.json`**; this table is orientation only.
 
-| Category | Stack |
-|---|---|
-| Runtime | Node.js ≥20, ESM (`"type": "module"`) |
+| Category              | Stack                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------ |
+| Runtime               | Node.js ≥20, ESM (`"type": "module"`)                                                      |
 | Bundle + declarations | `tsup` (JS) then `tsc --emitDeclarationOnly` (`.d.ts`); [details](#tsup--typescript-build) |
-| Dev runner | `tsx` |
-| Tests | `vitest` |
-| Lint/format | `@biomejs/biome` |
-| CLI args | `commander` |
+| Dev runner            | `tsx`                                                                                      |
+| Tests                 | `vitest`                                                                                   |
+| Lint/format           | `@biomejs/biome`                                                                           |
+| CLI args              | `commander`                                                                                |
 
 ---
 
@@ -88,4 +88,4 @@ system needed.
 
 **Scripts** — names and commands: **`package.json` → `scripts`**. **`build`** and **`prepare`** are covered under [tsup + TypeScript](#tsup--typescript-build); the only other convention to call out is **`test`** (runs `check` then Vitest) versus **`test:base`** (Vitest only, as in CI).
 
-**Dependencies** — **`package.json`** (`dependencies` / `devDependencies`) is canonical. The rationale sections above explain *why* each tool is there, not a parallel package list.
+**Dependencies** — **`package.json`** (`dependencies` / `devDependencies`) is canonical. The rationale sections above explain _why_ each tool is there, not a parallel package list.

--- a/test/directive.test.ts
+++ b/test/directive.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { tryParseDirective } from "../src/directive.js";
 
 describe("directive", () => {
@@ -10,7 +10,7 @@ describe("directive", () => {
 
     it("startRegion", () => {
       const d = tryParseDirective("#docregion");
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("");
       expect(d.args).toEqual([]);
@@ -18,7 +18,7 @@ describe("directive", () => {
 
     it("endRegion", () => {
       const d = tryParseDirective("#enddocregion");
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("endRegion");
       expect(d.rawArgs).toBe("");
       expect(d.args).toEqual([]);
@@ -30,7 +30,7 @@ describe("directive", () => {
     it("startRegion", () => {
       const spaces = "  ";
       const d = tryParseDirective(`${spaces}// #docregion`);
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("");
       expect(d.args).toEqual([]);
@@ -39,7 +39,7 @@ describe("directive", () => {
 
     it("endRegion", () => {
       const d = tryParseDirective(" #enddocregion a,b,  c  ");
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("endRegion");
       expect(d.rawArgs).toBe("a,b,  c");
       expect(d.args).toEqual(["a", "b", "c"]);
@@ -51,7 +51,7 @@ describe("directive", () => {
     describe("HTML:", () => {
       it("startRegion", () => {
         const d = tryParseDirective("<!--#docregion-->");
-        assert(d !== null);
+        expect(d).not.toBeNull();
         expect(d.kind).toBe("startRegion");
         expect(d.rawArgs).toBe("");
         expect(d.args).toEqual([]);
@@ -60,7 +60,7 @@ describe("directive", () => {
 
       it("endRegion", () => {
         const d = tryParseDirective("<!-- #enddocregion a -->  ");
-        assert(d !== null);
+        expect(d).not.toBeNull();
         expect(d.kind).toBe("endRegion");
         expect(d.rawArgs).toBe("a");
         expect(d.args).toEqual(["a"]);
@@ -71,7 +71,7 @@ describe("directive", () => {
     describe("CSS:", () => {
       it("startRegion", () => {
         const d = tryParseDirective("/*#docregion*/");
-        assert(d !== null);
+        expect(d).not.toBeNull();
         expect(d.kind).toBe("startRegion");
         expect(d.rawArgs).toBe("");
         expect(d.args).toEqual([]);
@@ -80,7 +80,7 @@ describe("directive", () => {
 
       it("endRegion", () => {
         const d = tryParseDirective("/* #enddocregion a */  ");
-        assert(d !== null);
+        expect(d).not.toBeNull();
         expect(d.kind).toBe("endRegion");
         expect(d.rawArgs).toBe("a");
         expect(d.args).toEqual(["a"]);
@@ -92,7 +92,7 @@ describe("directive", () => {
   describe("problem cases:", () => {
     it("Deprecated unquoted default region name", () => {
       const d = tryParseDirective("#docregion ,a");
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe(",a");
       expect(d.args).toEqual(["", "a"]);
@@ -101,7 +101,7 @@ describe("directive", () => {
 
     it('Duplicate "a" region', () => {
       const d = tryParseDirective("#docregion a,b,c,a");
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("a,b,c,a");
       expect(d.args).toEqual(["a", "b", "c"]);
@@ -110,7 +110,7 @@ describe("directive", () => {
 
     it('Duplicate "" region', () => {
       const d = tryParseDirective("#docregion '',''");
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("'',''");
       expect(d.args).toEqual([""]);
@@ -126,7 +126,7 @@ describe("directive", () => {
 
     it("#docregion '' parses as default region with no issues", () => {
       const d = tryParseDirective("#docregion ''");
-      assert(d !== null);
+      expect(d).not.toBeNull();
       expect(d.kind).toBe("startRegion");
       expect(d.args).toEqual([""]);
       expect(d.issues).toEqual([]);

--- a/test/directive.test.ts
+++ b/test/directive.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { tryParseDirective } from "../src/directive.js";
+import { expectDirective } from "./helpers.js";
 
 describe("directive", () => {
   describe("basic", () => {
@@ -10,7 +11,7 @@ describe("directive", () => {
 
     it("startRegion", () => {
       const d = tryParseDirective("#docregion");
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("");
       expect(d.args).toEqual([]);
@@ -18,7 +19,7 @@ describe("directive", () => {
 
     it("endRegion", () => {
       const d = tryParseDirective("#enddocregion");
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("endRegion");
       expect(d.rawArgs).toBe("");
       expect(d.args).toEqual([]);
@@ -30,7 +31,7 @@ describe("directive", () => {
     it("startRegion", () => {
       const spaces = "  ";
       const d = tryParseDirective(`${spaces}// #docregion`);
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("");
       expect(d.args).toEqual([]);
@@ -39,7 +40,7 @@ describe("directive", () => {
 
     it("endRegion", () => {
       const d = tryParseDirective(" #enddocregion a,b,  c  ");
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("endRegion");
       expect(d.rawArgs).toBe("a,b,  c");
       expect(d.args).toEqual(["a", "b", "c"]);
@@ -51,7 +52,7 @@ describe("directive", () => {
     describe("HTML:", () => {
       it("startRegion", () => {
         const d = tryParseDirective("<!--#docregion-->");
-        expect(d).not.toBeNull();
+        expectDirective(d);
         expect(d.kind).toBe("startRegion");
         expect(d.rawArgs).toBe("");
         expect(d.args).toEqual([]);
@@ -60,7 +61,7 @@ describe("directive", () => {
 
       it("endRegion", () => {
         const d = tryParseDirective("<!-- #enddocregion a -->  ");
-        expect(d).not.toBeNull();
+        expectDirective(d);
         expect(d.kind).toBe("endRegion");
         expect(d.rawArgs).toBe("a");
         expect(d.args).toEqual(["a"]);
@@ -71,7 +72,7 @@ describe("directive", () => {
     describe("CSS:", () => {
       it("startRegion", () => {
         const d = tryParseDirective("/*#docregion*/");
-        expect(d).not.toBeNull();
+        expectDirective(d);
         expect(d.kind).toBe("startRegion");
         expect(d.rawArgs).toBe("");
         expect(d.args).toEqual([]);
@@ -80,7 +81,7 @@ describe("directive", () => {
 
       it("endRegion", () => {
         const d = tryParseDirective("/* #enddocregion a */  ");
-        expect(d).not.toBeNull();
+        expectDirective(d);
         expect(d.kind).toBe("endRegion");
         expect(d.rawArgs).toBe("a");
         expect(d.args).toEqual(["a"]);
@@ -92,7 +93,7 @@ describe("directive", () => {
   describe("problem cases:", () => {
     it("Deprecated unquoted default region name", () => {
       const d = tryParseDirective("#docregion ,a");
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe(",a");
       expect(d.args).toEqual(["", "a"]);
@@ -101,7 +102,7 @@ describe("directive", () => {
 
     it('Duplicate "a" region', () => {
       const d = tryParseDirective("#docregion a,b,c,a");
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("a,b,c,a");
       expect(d.args).toEqual(["a", "b", "c"]);
@@ -110,7 +111,7 @@ describe("directive", () => {
 
     it('Duplicate "" region', () => {
       const d = tryParseDirective("#docregion '',''");
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("startRegion");
       expect(d.rawArgs).toBe("'',''");
       expect(d.args).toEqual([""]);
@@ -126,7 +127,7 @@ describe("directive", () => {
 
     it("#docregion '' parses as default region with no issues", () => {
       const d = tryParseDirective("#docregion ''");
-      expect(d).not.toBeNull();
+      expectDirective(d);
       expect(d.kind).toBe("startRegion");
       expect(d.args).toEqual([""]);
       expect(d.issues).toEqual([]);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared helpers for Vitest suites (narrowing, repeated checks, fixtures).
+ */
+import { expect } from "vitest";
+import type { Directive } from "../src/directive.js";
+
+/** Runtime check via Vitest; narrows `d` for TypeScript after the call. */
+export function expectDirective(d: Directive | null): asserts d is Directive {
+  expect(d).not.toBeNull();
+}


### PR DESCRIPTION
- Replaces long **AGENTS.md** content with a short index that links **README** and **docs/** (architecture, spec, plan, scope, tooling, conventions).
- Adds **docs/conventions.md** for TypeScript/Node style, Vitest/testing guidance, documentation DRY rules, and minimal-AGENTS guidance.
- Shortens **README.md**: lineage points to architecture; development points to tooling, conventions, and **CONTRIBUTING.md** instead of duplicating scripts.
- Adds **CONTRIBUTING.md** as a thin entry page that links README and conventions.
- Adds **test/helpers.ts** with **`expectDirective`** and uses it in **directive** tests so Vitest checks and TypeScript narrowing stay aligned.
- Reworks **docs/architecture.md** and **docs/scope.md** upstream sections into lists with collapsed reference links; keeps link definitions at file ends.
- Adjusts **docs/plan.md**, **docs/spec.md**, and **docs/tooling.md** for consistent formatting and link style (as in the branch diff).