### PR TITLE
Add excerpt transforms for Phase 2 and commit conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,5 @@ overview, installation, and clone workflow.
 - [docs/tooling.md](docs/tooling.md) — Tooling stack, rationale, and how scripts
   fit together (canonical script list: `package.json` → `scripts`)
 - [docs/conventions.md](docs/conventions.md) — Code style, Vitest testing style,
-  documentation DRY rules, and how to extend AGENTS vs `docs/`
+  documentation DRY rules, commit and PR expectations, and how to extend AGENTS
+  vs `docs/`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,16 +58,16 @@ All transforms are pure functions: `(lines: string[]) => string[]`.
 
 Supported transforms (in processing order):
 
-| Transform   | Description                                             |
-| ----------- | ------------------------------------------------------- |
-| `skip`      | Skip the first N lines                                  |
-| `take`      | Keep only the first N lines                             |
-| `from`      | Start from the first line matching a pattern            |
-| `to`        | Stop at (and exclude) the first line matching a pattern |
-| `remove`    | Remove all lines matching a pattern                     |
-| `retain`    | Keep only lines matching a pattern                      |
-| `replace`   | Replace pattern matches with a substitution string      |
-| `indent-by` | Prepend N spaces to every line                          |
+| Transform   | Description                                                       |
+| ----------- | ----------------------------------------------------------------- |
+| `skip`      | Skip the first N lines                                            |
+| `take`      | Keep only the first N lines                                       |
+| `from`      | Start from the first line matching a pattern                      |
+| `to`        | Truncate after the first line matching a pattern (that line kept) |
+| `remove`    | Remove all lines matching a pattern                               |
+| `retain`    | Keep only lines matching a pattern                                |
+| `replace`   | Replace pattern matches with a substitution string                |
+| `indent-by` | Prepend N spaces to every line                                    |
 
 Key porting note: `BackReferenceReplaceTransform` in Dart already targets JS
 regex back-reference semantics (`$1`, `$2`), so this is a straightforward port.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -51,6 +51,25 @@ and `.github/copilot-instructions.md`.
   (for example `package.json` for scripts and dependency pins).
 - Use simple, multilingual prose. Avoid idiomatic English.
 
+## Commits and pull requests
+
+Use the same bar as for any technical write-up: **complete sentences**, solid
+**grammar**, and **only detail that helps a reader** understand what changed and
+why. Prefer **plain language** over a dump of identifiers or internal jargon.
+
+- **Scope**: One commit (or one PR) should carry a **single logical change**
+  when practical; avoid mixing unrelated fixes and refactors.
+- **Size of message**: Match **depth to the size of the change**—a trivial fix
+  needs a short summary; a non-obvious change deserves a short **why** in the
+  body.
+- **Body format**: When there is a body beyond the subject line, write it as a
+  **Markdown list** (`-` items). Each item should be a **complete clause in
+  third person present tense** (for example: "Adds ...", "Documents ...",
+  "Refactors ...").
+- **Pull requests**: The description should stand alone: enough context for
+  review (motivation, trade-offs if any), without filler, repetition, or
+  marketing-style prose.
+
 ### AI guidance
 
 - Keep **[AGENTS.md](../AGENTS.md)** minimal: add depth in the appropriate

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -32,9 +32,9 @@ from [`chalin/code_excerpter`][].
 Transform pipeline: skip, take, from, to, remove, retain, replace, indent. All
 pure logic, no I/O.
 
-- [ ] Implement `src/transform.ts`
-- [ ] Write `test/transform.test.ts`
-- [ ] Update docs as needed
+- [x] Implement `src/transform.ts`
+- [x] Write `test/transform.test.ts`
+- [x] Update docs as needed
 
 ## Phase 3 — `inject.ts`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -64,7 +64,7 @@ all subsequent code fragment instructions in the same file.
 | `path-base`     | string                       | Sets the base directory for source file paths (set instruction) |
 | `region`        | string                       | Named region to extract (alternative to inline `(region)`)      |
 | `from`          | string/regex                 | Start extraction from the first line matching this pattern      |
-| `to`            | string/regex                 | End extraction before the first line matching this pattern      |
+| `to`            | string/regex                 | End after the first line matching this pattern (that line kept) |
 | `skip`          | integer                      | Skip the first N lines of the extracted region                  |
 | `take`          | integer                      | Take only the first N lines of the extracted region             |
 | `remove`        | string/regex                 | Remove all lines matching this pattern                          |

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,17 @@ export {
   extractExcerpts,
   maxUnindent,
 } from "./extract.js";
+export {
+  applyExcerptTransforms,
+  applyFrom,
+  applyRemove,
+  applyRetain,
+  applySkip,
+  applyTake,
+  applyTo,
+  encodeSlashChar,
+  type ExcerptTransformOptions,
+  type LinePredicate,
+  parseReplacePipeline,
+  patternToLinePredicate,
+} from "./transform.js";

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,1 +1,289 @@
-// To be implemented in Phase 2
+/**
+ * Excerpt transform pipeline: skip → take → from → to → remove → retain → replace → indent-by
+ * (see repository `docs/spec.md`; ported from `chalin/code_excerpt_updater` `code_transformer`).
+ */
+
+const escapedSlashRe = /\\\//g;
+const zeroChar = "\u0000";
+const endRe = /^g;?\s*$/;
+const matchDollarNumRe = /(\$+)(&|\d*)/g;
+const slashLetterRe = /\\([\\nt])/g;
+const slashHexRe = /\\x(..)/g;
+
+export type LinePredicate = (line: string) => boolean;
+
+/** Options for {@link applyExcerptTransforms}, mirroring `<?code-excerpt?>` transform arguments. */
+export interface ExcerptTransformOptions {
+  skip?: string;
+  take?: string;
+  from?: string;
+  to?: string;
+  remove?: string;
+  retain?: string;
+  replace?: string;
+  indentBy?: string;
+}
+
+function parseIntArg(s: string | undefined): number | null {
+  if (s === undefined) return null;
+  if (!/^[-+]?\d+$/.test(s)) return null;
+  const n = Number.parseInt(s, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function parseIndentBy(
+  s: string | undefined,
+  onError?: (msg: string) => void,
+): number {
+  if (s === undefined) return 0;
+  const n = Number.parseInt(s, 10);
+  if (Number.isNaN(n)) {
+    onError?.(`indent-by: error parsing integer value: ${JSON.stringify(s)}`);
+    return 0;
+  }
+  if (n < 0 || n > 100) {
+    onError?.(`indent-by: integer out of range: ${n}`);
+    return 0;
+  }
+  return n;
+}
+
+/**
+ * Builds a line predicate from a `from` / `to` / `remove` / `retain` argument:
+ * `/.../` is a regex test via {@link RegExp.prototype.test}; otherwise {@link String.prototype.includes}.
+ */
+export function patternToLinePredicate(
+  arg: string,
+  onError?: (msg: string) => void,
+): LinePredicate | null {
+  if (arg.startsWith("/") && arg.endsWith("/") && arg.length >= 2) {
+    const inner = arg.slice(1, -1);
+    try {
+      const re = new RegExp(inner);
+      return (line: string) => re.test(line);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      onError?.(`invalid regexp in pattern ${JSON.stringify(arg)}: ${msg}`);
+      return null;
+    }
+  }
+  const stringToMatch = arg.startsWith("\\/") ? arg.slice(1) : arg;
+  return (line: string) => line.includes(stringToMatch);
+}
+
+function indexWhere(lines: string[], pred: LinePredicate): number {
+  for (let i = 0; i < lines.length; i++) {
+    if (pred(lines[i])) return i;
+  }
+  return -1;
+}
+
+/** Drops the first `n` lines (`n >= 0`), or drops the last `-n` lines (`n < 0`). */
+export function applySkip(lines: string[], n: number): string[] {
+  if (n >= 0) return lines.slice(n);
+  return lines.slice(0, Math.max(0, lines.length + n));
+}
+
+/** Keeps the first `n` lines (`n >= 0`), or keeps the last `1 - n` lines (`n < 0`). */
+export function applyTake(lines: string[], n: number): string[] {
+  if (n >= 0) return lines.slice(0, n);
+  const k = lines.length + n - 1;
+  if (k < 0) return [];
+  return lines.slice(k);
+}
+
+/** Keeps from the first matching line through the end (inclusive). No match → empty. */
+export function applyFrom(lines: string[], pred: LinePredicate): string[] {
+  const i = indexWhere(lines, pred);
+  return i < 0 ? [] : lines.slice(i);
+}
+
+/** Keeps through the first matching line (inclusive). No match → unchanged. */
+export function applyTo(lines: string[], pred: LinePredicate): string[] {
+  const i = indexWhere(lines, pred);
+  if (i < 0) return lines;
+  return lines.slice(0, i + 1);
+}
+
+export function applyRemove(lines: string[], pred: LinePredicate): string[] {
+  return lines.filter((line) => !pred(line));
+}
+
+export function applyRetain(lines: string[], pred: LinePredicate): string[] {
+  return lines.filter(pred);
+}
+
+function slashCharToChar(ch: string): string {
+  switch (ch) {
+    case "n":
+      return "\n";
+    case "t":
+      return "\t";
+    case "\\":
+      return zeroChar;
+    default:
+      return `\\${ch}`;
+  }
+}
+
+function hexToChar(hexDigits: string): string {
+  const code = Number.parseInt(hexDigits, 16);
+  return Number.isNaN(code) ? `\\x${hexDigits}` : String.fromCodePoint(code);
+}
+
+/** Decodes `\n`, `\t`, `\\`, and `\xHH` in a replacement fragment (Dart `encodeSlashChar`). */
+export function encodeSlashChar(s: string): string {
+  return s
+    .replaceAll(slashLetterRe, (_, ch: string) => slashCharToChar(ch))
+    .replaceAll(slashHexRe, (_, hex: string) => hexToChar(hex))
+    .replaceAll(zeroChar, "\\");
+}
+
+function applyReplaceOne(
+  code: string,
+  reSource: string,
+  replacementRaw: string,
+): string {
+  const replacement = encodeSlashChar(replacementRaw);
+  const re = new RegExp(reSource, "g");
+
+  if (!matchDollarNumRe.test(replacement)) {
+    matchDollarNumRe.lastIndex = 0;
+    return code.replaceAll(re, replacement);
+  }
+  matchDollarNumRe.lastIndex = 0;
+
+  return code.replaceAll(re, (match, ...args: unknown[]) => {
+    const captureArgs = args.slice(0, -2) as string[];
+    const groupCount = captureArgs.length;
+
+    matchDollarNumRe.lastIndex = 0;
+    return replacement.replaceAll(
+      matchDollarNumRe,
+      (_m0, dollars: string, ref: string) => {
+        const numDollarChar = dollars.length;
+        const dollarOut = "$".repeat(numDollarChar >> 1);
+
+        if (numDollarChar % 2 === 0 || ref === "") {
+          return `${dollarOut}${ref}`;
+        }
+        if (ref === "&") return `${dollarOut}${match}`;
+
+        const argNum = Number.parseInt(ref, 10);
+        const resolved = Number.isNaN(argNum) ? groupCount + 1 : argNum;
+        if (resolved > groupCount) return `${dollarOut}$${ref}`;
+        const g = captureArgs[resolved - 1];
+        return `${dollarOut}${g ?? ""}`;
+      },
+    );
+  });
+}
+
+/**
+ * Parses a `replace` attribute like `/a/b/g;/c/d/g` and returns a function that applies
+ * all segments, or `null` if invalid (errors reported via `onError`).
+ */
+export function parseReplacePipeline(
+  replaceExp: string,
+  onError?: (msg: string) => void,
+): ((code: string) => string) | null {
+  const report = (detail: string): null => {
+    onError?.(
+      `invalid replace attribute (${JSON.stringify(replaceExp)}); ${detail}; ` +
+        "supported syntax is 1 or more semi-colon-separated: /regexp/replacement/g",
+    );
+    return null;
+  };
+
+  const parts = replaceExp
+    .replaceAll(escapedSlashRe, zeroChar)
+    .split("/")
+    .map((s) => s.replaceAll(zeroChar, "/"));
+
+  const len = parts.length;
+  if (len < 4 || len % 3 !== 1) {
+    return report(`argument has missing parts (${len})`);
+  }
+  if (parts[0] !== "") {
+    return report(
+      `argument should start with "/", not ${JSON.stringify(parts[0])}`,
+    );
+  }
+
+  const fns: ((code: string) => string)[] = [];
+  for (let i = 1; i < parts.length; i += 3) {
+    const reSource = parts[i];
+    const replacement = parts[i + 1];
+    const end = parts[i + 2];
+    if (!endRe.test(end)) {
+      return report(
+        `expected argument end syntax of "g" or "g;" but found ${JSON.stringify(end)}`,
+      );
+    }
+    try {
+      // Validate pattern early (applyReplaceOne also constructs RegExp)
+      new RegExp(reSource, "g");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return report(`bad regexp ${JSON.stringify(reSource)}: ${msg}`);
+    }
+    fns.push((code: string) => applyReplaceOne(code, reSource, replacement));
+  }
+
+  return (code: string) => fns.reduce((acc, fn) => fn(acc), code);
+}
+
+/**
+ * Applies transform options to excerpt lines in spec order. Does not mutate `lines`.
+ *
+ * @param onError - Parse/validation problems (indent-by, replace, bad `/regexp/` patterns).
+ */
+export function applyExcerptTransforms(
+  lines: string[],
+  options: ExcerptTransformOptions,
+  onError?: (msg: string) => void,
+): string[] {
+  let out = [...lines];
+
+  const skipN = parseIntArg(options.skip);
+  if (skipN !== null) out = applySkip(out, skipN);
+
+  const takeN = parseIntArg(options.take);
+  if (takeN !== null) out = applyTake(out, takeN);
+
+  if (options.from !== undefined) {
+    const pred = patternToLinePredicate(options.from, onError);
+    if (pred !== null) out = applyFrom(out, pred);
+  }
+
+  if (options.to !== undefined) {
+    const pred = patternToLinePredicate(options.to, onError);
+    if (pred !== null) out = applyTo(out, pred);
+  }
+
+  if (options.remove !== undefined) {
+    const pred = patternToLinePredicate(options.remove, onError);
+    if (pred !== null) out = applyRemove(out, pred);
+  }
+
+  if (options.retain !== undefined) {
+    const pred = patternToLinePredicate(options.retain, onError);
+    if (pred !== null) out = applyRetain(out, pred);
+  }
+
+  if (options.replace !== undefined && options.replace !== "") {
+    const pipeline = parseReplacePipeline(options.replace, onError);
+    if (pipeline !== null) {
+      const joined = out.join("\n");
+      out = pipeline(joined).split("\n");
+    }
+  }
+
+  const indent = parseIndentBy(options.indentBy, onError);
+  if (indent > 0) {
+    const prefix = " ".repeat(indent);
+    out = out.map((line) => prefix + line);
+  }
+
+  return out;
+}

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyExcerptTransforms,
+  applyFrom,
+  applyRemove,
+  applyRetain,
+  applySkip,
+  applyTake,
+  applyTo,
+  encodeSlashChar,
+  parseReplacePipeline,
+  patternToLinePredicate,
+} from "../src/transform.js";
+
+describe("transform", () => {
+  describe("patternToLinePredicate", () => {
+    it("substring match", () => {
+      const p = patternToLinePredicate("foo");
+      expect(p).not.toBeNull();
+      expect(p!("afoob")).toBe(true);
+      expect(p!("bar")).toBe(false);
+    });
+
+    it("regex form", () => {
+      const p = patternToLinePredicate("/^\\s{2}bar/");
+      expect(p).not.toBeNull();
+      expect(p!("  bar")).toBe(true);
+      expect(p!(" bar")).toBe(false);
+    });
+
+    it("invalid regexp reports and returns null", () => {
+      const onError = vi.fn();
+      const p = patternToLinePredicate("/(/", onError);
+      expect(p).toBeNull();
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  describe("applySkip", () => {
+    it("non-negative", () => {
+      expect(applySkip(["a", "b", "c"], 1)).toEqual(["b", "c"]);
+      expect(applySkip(["a", "b", "c"], 0)).toEqual(["a", "b", "c"]);
+    });
+
+    it("negative drops from end", () => {
+      expect(applySkip(["a", "b", "c"], -1)).toEqual(["a", "b"]);
+      expect(applySkip(["a", "b", "c"], -2)).toEqual(["a"]);
+    });
+  });
+
+  describe("applyTake", () => {
+    it("non-negative", () => {
+      expect(applyTake(["a", "b", "c"], 2)).toEqual(["a", "b"]);
+      expect(applyTake(["a", "b", "c"], 0)).toEqual([]);
+    });
+
+    it("negative keeps trailing slice", () => {
+      expect(applyTake(["a", "b", "c"], -1)).toEqual(["b", "c"]);
+      expect(applyTake(["a", "b", "c"], -2)).toEqual(["a", "b", "c"]);
+    });
+  });
+
+  describe("applyFrom", () => {
+    it("starts at first match", () => {
+      const pred = (s: string) => s.includes("x");
+      expect(applyFrom(["a", "bx", "c"], pred)).toEqual(["bx", "c"]);
+    });
+
+    it("no match yields empty", () => {
+      const pred = (s: string) => s.includes("z");
+      expect(applyFrom(["a", "b"], pred)).toEqual([]);
+    });
+  });
+
+  describe("applyTo", () => {
+    it("includes first matching line", () => {
+      const pred = (s: string) => s.includes("stop");
+      expect(applyTo(["a", "b stop", "c"], pred)).toEqual(["a", "b stop"]);
+    });
+
+    it("no match leaves lines unchanged", () => {
+      const pred = (s: string) => s.includes("z");
+      expect(applyTo(["a", "b"], pred)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("applyRemove / applyRetain", () => {
+    it("remove", () => {
+      const pred = (s: string) => /omit/.test(s);
+      expect(applyRemove(["keep", "omit this", "x"], pred)).toEqual([
+        "keep",
+        "x",
+      ]);
+    });
+
+    it("retain", () => {
+      const pred = (s: string) => s.startsWith("!");
+      expect(applyRetain(["a", "!b", "c", "!d"], pred)).toEqual(["!b", "!d"]);
+    });
+  });
+
+  describe("encodeSlashChar", () => {
+    it("decodes escapes", () => {
+      expect(encodeSlashChar(String.raw`a\n\t\\b`)).toBe("a\n\t\\b");
+    });
+
+    it("hex", () => {
+      expect(encodeSlashChar(String.raw`\x41`)).toBe("A");
+    });
+  });
+
+  describe("parseReplacePipeline", () => {
+    it("single segment", () => {
+      const fn = parseReplacePipeline(`/foo/bar/g`);
+      expect(fn).not.toBeNull();
+      expect(fn!("foo")).toBe("bar");
+    });
+
+    it("multiple segments compose left-to-right", () => {
+      const fn = parseReplacePipeline(`/a/x/g;/x/b/g`);
+      expect(fn).not.toBeNull();
+      expect(fn!("a")).toBe("b");
+    });
+
+    it("invalid reports via onError", () => {
+      const onError = vi.fn();
+      const fn = parseReplacePipeline(`foo`, onError);
+      expect(fn).toBeNull();
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  describe("applyExcerptTransforms", () => {
+    it("applies spec order: skip then take", () => {
+      const lines = ["a", "b", "c", "d", "e"];
+      const out = applyExcerptTransforms(lines, { skip: "1", take: "2" });
+      expect(out).toEqual(["b", "c"]);
+      expect(lines).toEqual(["a", "b", "c", "d", "e"]);
+    });
+
+    it("from then to", () => {
+      const out = applyExcerptTransforms(
+        ["skip", "one", "two", "end", "tail"],
+        { from: "one", to: "end" },
+      );
+      expect(out).toEqual(["one", "two", "end"]);
+    });
+
+    it("remove then retain", () => {
+      const out = applyExcerptTransforms(["ax", "b", "ay", "bz"], {
+        remove: "b",
+        retain: "a",
+      });
+      expect(out).toEqual(["ax", "ay"]);
+    });
+
+    it("replace then indent-by", () => {
+      const out = applyExcerptTransforms(["x1", "y1"], {
+        replace: `/1/!/g`,
+        indentBy: "2",
+      });
+      expect(out).toEqual(["  x!", "  y!"]);
+    });
+
+    it("replace with capture groups", () => {
+      const out = applyExcerptTransforms(["line:42"], {
+        replace: String.raw`/line:(\d+)/L$1/g`,
+      });
+      expect(out).toEqual(["L42"]);
+    });
+
+    it("indent-by out of range", () => {
+      const onError = vi.fn();
+      const out = applyExcerptTransforms(["a"], { indentBy: "101" }, onError);
+      expect(out).toEqual(["a"]);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it("omit replace when invalid", () => {
+      const onError = vi.fn();
+      const out = applyExcerptTransforms(["ab"], { replace: "bad" }, onError);
+      expect(out).toEqual(["ab"]);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it("invalid skip is ignored", () => {
+      expect(applyExcerptTransforms(["a", "b"], { skip: "x" })).toEqual([
+        "a",
+        "b",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
- Implements `applyExcerptTransforms` and related helpers in `src/transform.ts`.
- Adds `test/transform.test.ts` with coverage for the pipeline and edge cases.
- Marks Phase 2 complete in `docs/plan.md`.
- Aligns `to` transform documentation with Dart semantics in `docs/spec.md` and `docs/architecture.md`.
- Adds commit and pull request guidance to `docs/conventions.md`, including Markdown list bodies in third person present tense.
- Updates `AGENTS.md` so the conventions doc index mentions commit and PR expectations.