### PR TITLE
feat: surface parsed excerpt directive counts in API and CLI

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,12 @@ orchestrates the extraction + transform pipeline for each code block.
   [`chalin/code_excerpt_updater`][] (see that directory’s `README.md`).
 - See [`docs/spec.md`](spec.md) for the full instruction syntax.
 
+### `src/instructionStats.ts`
+
+Shared **`InstructionStats`** type (`set` / `fragment` parsed-directive counts).
+Imported by `inject.ts` (optional context field) and `update.ts` (aggregated on
+`UpdateResult`); re-exported from the package root in `index.ts`.
+
 ### `src/update.ts` (Phase 4)
 
 **Dart source:** `dart-lang/site-shared/pkgs/excerpter/lib/src/update.dart`
@@ -106,7 +112,9 @@ Walks directory trees (or individual files), collects `.md` files, and runs
 `injectMarkdown` on each. Writes updated content back when changed.
 
 - `updatePaths(paths, options?)` — async entry point; returns `UpdateResult`
-  with `filesProcessed`, `filesUpdated`, `errors[]`, `warnings[]`.
+  with `filesProcessed`, `filesUpdated`, `errors[]`, `warnings[]`, and
+  `instructionStats` (`set` / `fragment` counts of **parsed** strict-line
+  directives for the run).
 - Skips dot-prefixed segments and user-supplied `exclude` regex patterns.
 - Source files for excerpts are read synchronously from disk under
   `options.pathBase` (resolved to an absolute root for `readFile` only).

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -89,6 +89,20 @@ C. [ ] Test gaps:
 3. [x] `updatePaths`: duplicate / overlapping roots (dedupe; see
        `test/update.test.ts`).
 
+D. [ ] **Revisit — `<?code-excerpt` in prose (e.g. markdown tables):** Today
+`injectMarkdown` treats any line **containing** the substring `<?code-excerpt`
+as a candidate PI; if the strict full-line regex does not match and the
+line-start `PROC_INSTR_BODY` regex also does not match (e.g. the PI text appears
+**mid-line** in documentation), the tool reports **invalid processing
+instruction**. That is awkward for docs that quote the syntax literally.
+**Current workaround:** escape the opening angle bracket in prose (e.g.
+`&lt;?code-excerpt …?>`) so the raw line does not contain `<?code-excerpt`.
+**Possible later change:** only run PI parsing / errors when there is a real
+line-start PI attempt (`PROC_INSTR_BODY` matches), so mid-line mentions are left
+alone; add a regression test and optionally document `&lt;` in
+[`docs/spec.md`](spec.md) for rare line-start edge cases (aligned with XML PI
+rules).
+
 ## Phase 5 — Integration Testing
 
 Run against [`dart-lang/site-www`](https://github.com/dart-lang/site-www) and

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ program
       if (!compiled.ok) {
         console.error(compiled.error);
         console.error(
-          "0 file(s) processed, 0 updated, 0 error(s), 0 warning(s)",
+          "0 file(s) processed, 0 updated, 0 error(s), 0 warning(s); 0 set directive(s), 0 fragment directive(s)",
         );
         process.exitCode = 1;
         return;
@@ -67,13 +67,16 @@ program
         log: (msg) => console.error(msg),
       });
 
+      const { set, fragment } = result.instructionStats;
       const summary = [
         `${result.filesProcessed} file(s) processed`,
         `${result.filesUpdated} updated`,
         `${result.errors.length} error(s)`,
         `${result.warnings.length} warning(s)`,
       ].join(", ");
-      console.error(summary);
+      console.error(
+        `${summary}; ${set} set directive(s), ${fragment} fragment directive(s)`,
+      );
 
       if (result.errors.length > 0) {
         process.exitCode = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   getExcerptRegionLines,
   maxUnindent,
 } from "./extract.js";
+export { type InstructionStats } from "./instructionStats.js";
 export {
   injectMarkdown,
   type MarkdownInjectContext,

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -4,6 +4,7 @@ import {
   dropTrailingBlankLines,
   getExcerptRegionLines,
 } from "./extract.js";
+import type { InstructionStats } from "./instructionStats.js";
 import {
   applyExcerptTransformsInOrder,
   parseIndentBy,
@@ -21,7 +22,7 @@ const PROC_INSTR_BODY =
 
 /**
  * Strict match: the **entire line** is only a `<?code-excerpt ...?>` plus optional trailing
- * whitespace (Dart `procInstrRE` semantics with a `$` anchor). Export for tests and
+ * whitespace (whole-line match with a `$` anchor). Export for tests and
  * tooling; lines with extra text after `?>` do not match — see `injectMarkdown`’s
  * `onWarning` path (`processing instruction ignored: extraneous text after closing "?>"`).
  */
@@ -42,9 +43,9 @@ const SET_KNOWN_KEYS = new Set([
 
 interface ParsedNamedArgs {
   map: Map<string, string>;
-  /** Keys present as bare flags (`plaster` with no `=`), matching Dart `argValue == null`. */
+  /** Keys present as bare flags (`plaster` with no `=`). */
   flags: Set<string>;
-  /** First-occurrence order of every named key (Dart `LinkedHashMap` iteration). */
+  /** First-occurrence order of every named key (insertion order in the PI). */
   keyOrder: string[];
 }
 
@@ -59,43 +60,51 @@ const NON_WORD = /[^\w]+/g;
 
 export interface MarkdownInjectContext {
   /**
-   * Reads source text for a path relative to the current `path-base`
-   * (POSIX-style join of `pathBase` + relative path). Return `null` if the file is missing.
+   * Reads source text for a path relative to the current `path-base`. Returns
+   * `null` if the file is missing or cannot be read.
    *
-   * When `region` is non-empty, callers mirroring Dart `ExcerptGetter` should resolve
-   * `basename-region.ext` fragment files (legacy mode) or the matching key in
-   * `.excerpt.yaml` (YAML mode).
+   * When `region` is non-empty, callers using fragment or YAML excerpt sources
+   * may resolve `basename-region.ext` files (legacy mode) or the matching key
+   * in `.excerpt.yaml` (YAML mode).
    *
-   * The optional `region` parameter was added for Dart `ExcerptGetter` parity;
-   * simple callers that rely on `getExcerptRegionLines` for region extraction
-   * may ignore it.
+   * Callers that only use `getExcerptRegionLines` on the returned file text may
+   * ignore `region`.
    */
   readFile: (relativePath: string, region?: string) => string | null;
   /** Initial `path-base` (directory prefix for excerpt sources). */
   pathBase?: string;
   /**
-   * When `true`, applies language plaster templates like the Dart YAML excerpt
-   * path (default `false`, matching legacy fragment mode).
+   * When `true`, applies language-specific plaster templates in YAML excerpt
+   * mode (default `false`, legacy fragment-style behavior).
    */
   excerptsYaml?: boolean;
-  /** Default extra spaces when `indent-by` is omitted (Dart `defaultIndentation`). */
+  /** Default extra spaces when `indent-by` is omitted on a fragment directive. */
   defaultIndentation?: number;
   /**
-   * Global replace expression (Dart CLI `globalReplaceExpr`). Applied after
-   * per-instruction transforms and after file-level set `replace`, on the joined
-   * excerpt string (same compose order as Dart `fileAndCmdLineCodeTransformer`).
+   * Global replace expression. Applied after per-instruction transforms and
+   * file-level set `replace`, on the joined excerpt string.
    */
   globalReplace?: string;
   /**
    * Default plaster template when neither the PI nor a file-level `plaster` set
-   * instruction overrides it (Dart `globalPlasterTemplate`).
+   * instruction overrides it.
    */
   globalPlasterTemplate?: string;
   /**
-   * When `true` (default), escape Angular-style `{{` / `}}` in injected lines
-   * like the Dart updater (`escapeNgInterpolation`).
+   * When `true` (default), escape Angular-style `{{` / `}}` in injected lines.
    */
   escapeNgInterpolation?: boolean;
+  /**
+   * When provided, incremented for each **strict-line** `<?code-excerpt …?>`
+   * that is **parsed** (`set` for set-only, `fragment` for quoted path + fence);
+   * processing may still report errors for that directive afterward.
+   * Aggregated on `UpdateResult` by `updatePaths`.
+   *
+   * Reusing the same {@link InstructionStats} object across multiple
+   * `injectMarkdown` calls **accumulates** counts; reset `set` and `fragment` to
+   * `0` first if you want per-call totals.
+   */
+  instructionStats?: InstructionStats;
   onWarning?: (msg: string) => void;
   onError?: (msg: string) => void;
 }
@@ -176,7 +185,7 @@ function codeLang(openingFenceLine: string, path: string): string {
   return fileExtensionLower(path);
 }
 
-/** Dart `escapeNgInterpolation`: `{{` → `{!{`, `}}` → `}!}`. */
+/** Escapes Angular-style `{{` / `}}` as `{!{` / `}!}` when enabled. */
 function escapeNgLine(line: string, enabled: boolean): string {
   if (!enabled) return line;
   return line.replace(/\{\{|\}\}/g, (m) => (m === "{{" ? "{!{" : "}!}"));
@@ -201,7 +210,11 @@ function plasterTemplateForLang(lang: string): string | null {
   }
 }
 
-/** Dart `PlasterCodeTransformer`: `none`, legacy (no-op except `none`), or yaml templates. */
+/**
+ * Plaster pass: `plaster="none"` removes default-plaster lines; if `excerptsYaml`
+ * is false, returns lines unchanged; otherwise substitutes language templates
+ * around `DEFAULT_PLASTER`.
+ */
 function applyPlasterToLines(
   lines: string[],
   plasterTemplate: string | undefined,
@@ -476,6 +489,12 @@ export function injectMarkdown(
 
     const { linePrefix, unnamed, named } = match.groups;
     const namedStr = named ?? "";
+
+    const st = ctx.instructionStats;
+    if (st) {
+      if (unnamed === undefined) st.set++;
+      else st.fragment++;
+    }
 
     if (unnamed === undefined) {
       handleSetInstruction(parseNamedArgs(namedStr, err));

--- a/src/instructionStats.ts
+++ b/src/instructionStats.ts
@@ -1,0 +1,15 @@
+/**
+ * Counts of **parsed** strict-line `<?code-excerpt …?>` directives (a strict-line
+ * match; the directive may still error afterward).
+ *
+ * `updatePaths` shares one instance across every `injectMarkdown` call and
+ * returns it on `UpdateResult.instructionStats`. Callers using
+ * `injectMarkdown` only may supply their own object on the inject context for
+ * optional totals.
+ */
+export interface InstructionStats {
+  /** Set-only directives (`path-base`, `replace`, `plaster`, etc.). */
+  set: number;
+  /** Fragment directives (quoted path + following code fence). */
+  fragment: number;
+}

--- a/src/update.ts
+++ b/src/update.ts
@@ -9,6 +9,7 @@ import { readFileSync } from "node:fs";
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { injectMarkdown, type MarkdownInjectContext } from "./inject.js";
+import type { InstructionStats } from "./instructionStats.js";
 
 const MD_EXT = /\.md$/;
 const DOT_SEGMENT = /(^|[/\\])\./;
@@ -34,11 +35,15 @@ export interface UpdateOptions {
   log?: (msg: string) => void;
 }
 
+export type { InstructionStats } from "./instructionStats.js";
+
 export interface UpdateResult {
   filesProcessed: number;
   filesUpdated: number;
   errors: string[];
   warnings: string[];
+  /** Totals across all processed markdown files. */
+  instructionStats: InstructionStats;
 }
 
 function shouldExclude(relPath: string, patterns: RegExp[]): boolean {
@@ -105,11 +110,13 @@ export async function updatePaths(
   const dryRun = opts.dryRun ?? false;
   const log = opts.log ?? (() => {});
   const srcRoot = resolve(opts.pathBase ?? "");
+  const instructionStats: InstructionStats = { set: 0, fragment: 0 };
   const result: UpdateResult = {
     filesProcessed: 0,
     filesUpdated: 0,
     errors: [],
     warnings: [],
+    instructionStats,
   };
 
   const allFiles: string[] = [];
@@ -134,6 +141,7 @@ export async function updatePaths(
       escapeNgInterpolation: opts.escapeNgInterpolation,
       globalReplace: opts.globalReplace,
       globalPlasterTemplate: opts.globalPlasterTemplate,
+      instructionStats,
       onWarning: (msg) => {
         const w = `warning: ${filePath}: ${msg}`;
         result.warnings.push(w);

--- a/test/cli.integration.test.ts
+++ b/test/cli.integration.test.ts
@@ -125,7 +125,9 @@ describe("CLI (integration)", () => {
     expect(status, "exit code").toBe(1);
     expect(stdout).toBe("");
     expect(stderr).toMatch(/needs update:/);
-    expect(stderr).toMatch(/1 file\(s\) processed,\s*1 updated/);
+    expect(stderr).toMatch(
+      /1 file\(s\) processed, 1 updated, \d+ error\(s\), \d+ warning\(s\); \d+ set directive\(s\), 1 fragment directive\(s\)/,
+    );
     expect(readFileSync(mdPath, "utf8")).toBe(md);
   });
 });

--- a/test/directive.test.ts
+++ b/test/directive.test.ts
@@ -119,6 +119,7 @@ describe("directive", () => {
     });
   });
 
+  // cSpell:ignore docregionfoo
   describe("edge cases", () => {
     it("word boundary: #docregionfoo is not a directive", () => {
       const d = tryParseDirective("the word #docregionfoo is not a directive");

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -74,6 +74,26 @@ final x = 1;
       expect(out).toContain("// ok");
     });
 
+    it("increments instructionStats for parsed set and fragment directives", () => {
+      const instructionStats = { set: 0, fragment: 0 };
+      const src = "// ok\n";
+      const md = [
+        '<?code-excerpt path-base="p"?>',
+        '<?code-excerpt "b.dart"?>',
+        "",
+        "```",
+        ".",
+        "```",
+        "",
+      ].join("\n");
+      injectMarkdown(md, {
+        ...ctx({ "p/b.dart": src }),
+        instructionStats,
+      });
+      expect(instructionStats.set).toBe(1);
+      expect(instructionStats.fragment).toBe(1);
+    });
+
     it("applies skip transform", () => {
       const src = `// #docregion
 a

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -139,6 +139,7 @@ describe("updatePaths", () => {
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(1);
     expect(result.errors).toEqual([]);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
 
     const updated = readFileSync(join(docs, "guide.md"), "utf8");
     expect(updated).toContain("var greeting = 'hello';");
@@ -177,6 +178,7 @@ describe("updatePaths", () => {
 
     expect(result.errors, result.errors.join("\n")).toEqual([]);
     expect(result.filesUpdated).toBe(1);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
     expect(readFileSync(join(docs, "page.md"), "utf8")).toContain(
       "const k = 42;",
     );
@@ -207,6 +209,7 @@ describe("updatePaths", () => {
 
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(0);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
     expect(readFileSync(join(docs, "already-ok.md"), "utf8")).toBe(md);
   });
 
@@ -232,6 +235,7 @@ describe("updatePaths", () => {
 
     expect(result.filesProcessed).toBe(2);
     expect(result.filesUpdated).toBe(2);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 2 });
   });
 
   it("skips dot-prefixed directories", async () => {
@@ -244,6 +248,7 @@ describe("updatePaths", () => {
     const result = await updatePaths([docs]);
 
     expect(result.filesProcessed).toBe(1);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("respects --exclude patterns", async () => {
@@ -258,6 +263,7 @@ describe("updatePaths", () => {
     });
 
     expect(result.filesProcessed).toBe(1);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("dedupes the same root passed more than once", async () => {
@@ -266,6 +272,7 @@ describe("updatePaths", () => {
     writeFixture(docs, "a.md", "no PI\n");
     const result = await updatePaths([docs, docs]);
     expect(result.filesProcessed).toBe(1);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("dedupes overlapping roots when a subdirectory is also listed", async () => {
@@ -274,6 +281,7 @@ describe("updatePaths", () => {
     writeFixture(docs, "sub/page.md", "no PI\n");
     const result = await updatePaths([docs, join(docs, "sub")]);
     expect(result.filesProcessed).toBe(1);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("skips markdown when the sole root is a dot-prefixed directory", async () => {
@@ -285,6 +293,7 @@ describe("updatePaths", () => {
     const result = await updatePaths([root]);
 
     expect(result.filesProcessed).toBe(0);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("skips markdown when the sole root matches --exclude", async () => {
@@ -296,6 +305,7 @@ describe("updatePaths", () => {
     const result = await updatePaths([root], { exclude: [/vendor/] });
 
     expect(result.filesProcessed).toBe(0);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("dry-run does not write files", async () => {
@@ -320,6 +330,7 @@ describe("updatePaths", () => {
     });
 
     expect(result.filesUpdated).toBe(1);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
     expect(readFileSync(join(docs, "dry.md"), "utf8")).toBe(original);
   });
 
@@ -339,6 +350,7 @@ describe("updatePaths", () => {
 
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toMatch(/cannot read source file/);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
   });
 
   it("records an error when a root path does not exist", async () => {
@@ -354,6 +366,7 @@ describe("updatePaths", () => {
     expect(result.filesUpdated).toBe(0);
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toMatch(/ENOENT|no such file|not found/i);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("still processes existing roots when another root path is missing", async () => {
@@ -372,6 +385,7 @@ describe("updatePaths", () => {
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(0);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("accepts individual files as paths", async () => {
@@ -382,6 +396,7 @@ describe("updatePaths", () => {
 
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(0);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("skips a dot-prefixed markdown file when passed as a single-file path", async () => {
@@ -391,8 +406,10 @@ describe("updatePaths", () => {
     const result = await updatePaths([join(tmp, ".secret.md")]);
 
     expect(result.filesProcessed).toBe(0);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
+  // cSpell:ignore skipme
   it("skips a single-file path when the basename matches --exclude", async () => {
     const tmp = useTmp();
     writeFixture(tmp, "skipme.md", "no PI\n");
@@ -402,6 +419,7 @@ describe("updatePaths", () => {
     });
 
     expect(result.filesProcessed).toBe(0);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("skips non-md files when given a directory", async () => {
@@ -413,6 +431,7 @@ describe("updatePaths", () => {
     const result = await updatePaths([tmp]);
 
     expect(result.filesProcessed).toBe(1);
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
   });
 
   it("passes globalReplace through to injectMarkdown", async () => {
@@ -427,11 +446,12 @@ describe("updatePaths", () => {
       ['<?code-excerpt "r.dart"?>', "", "```dart", "old", "```", ""].join("\n"),
     );
 
-    await updatePaths([docs], {
+    const result = await updatePaths([docs], {
       pathBase: src,
       globalReplace: "/hello/world/g",
     });
 
+    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
     const updated = readFileSync(join(docs, "gr.md"), "utf8");
     expect(updated).toContain("world");
     expect(updated).not.toContain("hello");


### PR DESCRIPTION
- Adds `InstructionStats` and aggregates set/fragment counts in `updatePaths`
- Exports `InstructionStats` from the package root and re-exports it from `update.ts`
- Extends `injectMarkdown` to increment optional stats and documents reuse semantics
- Prints directive totals in the CLI summary after a semicolon
- Documents the stats module and `UpdateResult` field in `docs/architecture.md`
- Records the prose `<?code-excerpt` follow-up in `docs/plan.md`
- Rewrites `MarkdownInjectContext` JSDoc without Dart-only breadcrumbs
- Asserts stats across `updatePaths` scenarios and extends inject and CLI tests
- Adds cspell ignore hints in tests where fixture names trip the dictionary