### PR TITLE
Expands default plaster language coverage and tightens docs/tests

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -37,6 +37,8 @@ words:
   - docregion
   - docplaster
   - enddocregion
+  - erlang
   - excerpter
+  - kotlin
   - nvmrc
   - pkgs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 ### Added
 
 - CLI **`--version`**, reporting `version` from `package.json`.
+- Plaster templates for common fenced-code language identifiers, including
+  `javascript`, `typescript`, `csharp`, `cs`, and more.
 
 ### Changed
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -11,7 +11,7 @@ section may list limitations that apply to that phase.
 ## Phase 1a — `directive.ts`
 
 Parse `#docregion`/`#enddocregion` directives from source lines. Pure string
-logic, no I/O. Port the `Directive` class from [`chalin/code_excerpter`][] with
+logic, no I/O. Port the `Directive` class from [chalin/code_excerpter][] with
 comment-syntax-aware regex (HTML `-->`, CSS `*/`).
 
 - [x] Implement `src/directive.ts`
@@ -21,12 +21,12 @@ comment-syntax-aware regex (HTML `-->`, CSS `*/`).
 ## Phase 1b — `extract.ts`
 
 Extract named code regions from source file content. Port the `Excerpter` class
-from [`chalin/code_excerpter`][].
+from [chalin/code_excerpter][].
 
 - [x] Implement `src/extract.ts`
 - [x] Write `test/extract.test.ts`
 - [x] Port comprehensive test cases from
-      [`chalin/code_excerpter/test/excerpter_test.dart`][] (edge cases, plaster,
+      [chalin/code_excerpter/test/excerpter_test.dart][] (edge cases, plaster,
       overlapping regions)
 - [x] Update docs as needed
 
@@ -61,6 +61,8 @@ Directory walking, file updating, CLI entry point.
 - [x] Implement `src/cli.ts`
 - [x] Write `test/update.test.ts`
 - [x] Update docs as needed
+
+## Phase 5a - follow-ups
 
 A. [ ] **Follow-up** (site-shared updater goldens; complements Phase 3’s
 [code_excerpt_updater test_data][] inject-only goldens):
@@ -103,18 +105,44 @@ alone; add a regression test and optionally document `&lt;` in
 [`docs/spec.md`](spec.md) for rare line-start edge cases (aligned with XML PI
 rules).
 
-## Phase 5 — Integration Testing
+## Phase 5b - extra behavior
 
-Run against [`dart-lang/site-www`](https://github.com/dart-lang/site-www) and
-diff output against the Dart tool.
+### Refreshing code excerpts in non-md files
 
-- [ ] Set up integration test harness
-- [ ] Run against `dart-lang/site-www`
-- [ ] Compare output with the Dart excerpter
-- [ ] Document any discrepancies
+- Currently, `updatePaths` / CLI only processes `.md` files.
+- Upstream [chalin/code_excerpt_updater CLI][] also processed `.dart` and
+  `.jade` (`_validExt`).
+- Newer [dart-lang/site-shared excerpter][]: [excerpter `update.dart`][] uses
+  configurable `validTargetExtensions`; [excerpter `bin/excerpter.dart`][]
+  passes `{'.md'}` only. Fixture shape:
+  `test/fixtures/code-excerpt-updater/test_data/src/basic_with_region.dart`.
+- Consider bringing in this new behavior into `code-excerpter`.
+- If/once this is added, update [docs/spec.md](spec.md#pi-line-prefixes) to
+  reflect the new behavior, in particular the list bullet prefix, add:
+  > - Multiline comment continuation prefix: `*`
 
-[`chalin/code_excerpter`]: https://github.com/chalin/code_excerpter
-[`chalin/code_excerpter/test/excerpter_test.dart`]:
+[chalin/code_excerpt_updater CLI]:
+  https://github.com/chalin/code_excerpt_updater/blob/main/lib/code_excerpt_updater_cli.dart
+[dart-lang/site-shared excerpter]:
+  https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter
+[excerpter `update.dart`]:
+  https://github.com/dart-lang/site-shared/blob/main/pkgs/excerpter/lib/src/update.dart
+[excerpter `bin/excerpter.dart`]:
+  https://github.com/dart-lang/site-shared/blob/main/pkgs/excerpter/bin/excerpter.dart
+
+## Phase 6 - Integration Testing
+
+Run the code-excerpter against a repo that uses one of the other excerpter tool
+versions, such as:
+
+- [ ] (IN PROGRESS) [open-telemetry/opentelemetry.io][]
+- [ ] [dart-lang/site-www][]
+
+[open-telemetry/opentelemetry.io]:
+  https://github.com/open-telemetry/opentelemetry.io
+[dart-lang/site-www]: https://github.com/dart-lang/site-www
+[chalin/code_excerpter]: https://github.com/chalin/code_excerpter
+[chalin/code_excerpter/test/excerpter_test.dart]:
   https://github.com/chalin/code_excerpter/blob/master/test/excerpter_test.dart
 [dart-lang/site-shared pkgs/excerpter test_data]:
   https://github.com/dart-lang/site-shared/tree/main/pkgs/excerpter/test_data
@@ -122,3 +150,5 @@ diff output against the Dart tool.
   https://github.com/dart-lang/site-shared/blob/main/pkgs/excerpter/test/updater_test.dart
 [code_excerpt_updater test_data]:
   https://github.com/chalin/code_excerpt_updater/tree/main/test_data
+
+<!-- cSpell:ignore opentelemetry -->

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,26 +1,22 @@
-# Specification: `<?code-excerpt?>` Instruction Syntax
+# Specification: `<?code-excerpt?>` processing instruction syntax and more
 
-This document specifies the `<?code-excerpt?>` processing instruction syntax
-used to inject code excerpts into markdown documentation files. It is adapted
-from the
-[`chalin/code_excerpt_updater`](https://github.com/chalin/code_excerpt_updater)
-README, which is the canonical reference.
+This document specifies:
 
----
-
-## Overview
-
-`code-excerpter` processes markdown files looking for XML processing
-instructions of the form `<?code-excerpt?>`. When found, the tool extracts the
-referenced code from the source file, applies any transforms, and replaces the
-fenced or prettify code block that immediately follows the instruction.
-
-A matching line must contain **only** the processing instruction (optional
-trailing whitespace). Any non-whitespace after the closing `?>` is ignored: the
-line is not treated as an instruction and a **warning** is reported (the
-document is unchanged for that line).
+- `<?code-excerpt?>` processing instruction syntax and semantics
+- [Instruction and fence prefixes](#instruction-and-fence-prefixes)
+- [Source file directives](#source-file-directives): `#docregion` /
+  `#enddocregion`
+- [Plaster handling](#plaster-handling)
 
 ---
+
+## `<?code-excerpt?>` processing instruction (PI)
+
+The `code-excerpter` processes markdown files looking for XML **processing
+instructions** (PIs) of the form `<?code-excerpt?>`. PIs identify the source
+file, region, and transforms to apply to the code excerpt, allowing for
+`code-excerpter` to refresh code blocks when their originating source code
+changes.
 
 ## Instruction Forms
 
@@ -34,8 +30,13 @@ Specifies a source file (and optionally a named region) to inject:
 
 - The first positional argument is a quoted path + optional region string.
 - The path is relative to the configured `path-base`.
-- The region name (in parentheses) is optional; if omitted, the default region
-  is used (the entire file, minus directive lines).
+- The region name (in parentheses) is optional; if it is omitted and no
+  `region=` argument is given, the **default region** (empty name) is used.
+  Source files:
+  - **without** `#docregion` / `#enddocregion` yield the entire file (minus
+    directives).
+  - **with** `#docregion` / `#enddocregion` directives resolve the
+    [Default region](#default-region).
 - Additional named arguments follow as `key="value"` pairs.
 
 **Example:**
@@ -48,24 +49,33 @@ Specifies a source file (and optionally a named region) to inject:
 ```
 ````
 
-Supported fences are Markdown backtick fences (` ``` ` … ` ``` `) and Liquid
-`{% prettify … %}` … `{% endprettify %}` pairs. Other Liquid tags (for example
-`{% if %}`) are not treated as code fences.
+Supported fences are:
+
+- Markdown code-block fences using either syntax:
+  - backtick fences (` ``` ` ... ` ``` `) or
+  - tilde fences (`~~~` … `~~~`)
+- Hugo/Liquid `{% prettify … %}` ... `{% endprettify %}` pairs.
 
 ### Set instruction
 
-Sets a persistent value for the current file, such as `path-base`:
+Sets a persistent value for the current file. Typical keys are `path-base`,
+file-level `replace`, and file-level `plaster`:
 
 ```text
 <?code-excerpt path-base="examples/ng/doc"?>
 ```
 
-A set instruction has no path argument and no following code block. It affects
-all subsequent code fragment instructions in the same file.
-
----
+A set instruction has no path argument and no following code block. Each set
+line must contain **at most one** named argument (or one bare flag such as
+`plaster` with no `=`). Set values apply to all subsequent fragment instructions
+in the same file until another set instruction for that key replaces them.
 
 ## Recognized Arguments
+
+Fragment instructions may use the following named arguments (plus the positional
+path string). Set instructions accept **only** `path-base`, `replace`,
+`plaster`, or no-op compatibility keys `class` / `title`—see
+[Set instruction](#set-instruction); any other set key triggers a warning.
 
 | Argument        | Type                         | Description                                                     |
 | --------------- | ---------------------------- | --------------------------------------------------------------- |
@@ -82,21 +92,23 @@ all subsequent code fragment instructions in the same file.
 | `indent-by`     | integer                      | Prepend N spaces to every output line                           |
 | `plaster`       | string                       | Override the plaster comment (use `"none"` to disable)          |
 
+On a fragment, `replace` and `plaster` participate in the transform or plaster
+pass for that excerpt only. As the **sole** argument on a
+[set instruction](#set-instruction), they set file-level defaults (`replace`
+runs on the joined excerpt after fragment transforms; `plaster` sets the
+template for later fragments, and bare `plaster` clears the file default).
+
 ### Limitations
 
 - XML processing instructions cannot contain unescaped `>` characters. Use
   `&gt;` if a `>` is needed in a pattern value.
 
----
-
 ## Processing Order of Arguments
 
-When multiple transform arguments are present, `injectMarkdown` applies them in
-**the order they appear** in the processing instruction (Dart `Map.forEach`
-insertion order on named arguments), not a fixed global ordering. For example,
-`replace` before `retain` runs replace first, then retain.
+When multiple transform arguments are present, `code-excerpter` applies them in
+**the order they appear** in the processing instruction.
 
-The usual relative order in docs is:
+The usual relative order is:
 
 1. `skip`
 2. `take`
@@ -106,34 +118,45 @@ The usual relative order in docs is:
 6. `retain`
 7. `replace`
 
-`indent-by` is handled separately after the transform chain (Dart `indent-by`).
+`indent-by` is handled separately after the transform chain.
+
+## Instruction and fence prefixes
+
+### PI line prefixes
+
+In addition to indentation, a `<?code-excerpt?>` line may include an optional
+margin token prefix:
+
+- Markdown list bullet: `-` or `*`
+- Line comment prefix: `//` or `///`
+
+### Fence line prefixes
+
+- Line comment prefix: `//` or `///`
+
+## Optional trailing whitespace for instruction lines
+
+Any whitespace following the closing `?>` is ignored. Any non-whitespace after
+the closing `?>` is reported via a warning and the document is left unchanged
+for that line.
 
 ---
 
-## Comment-Prefixed Instructions
+## Source file directives
 
-`<?code-excerpt?>` instructions may be preceded by a comment prefix when the
-markdown file requires it (e.g., inside an HTML comment block):
-
-<!-- prettier-ignore -->
-```markdown
-// <?code-excerpt "lib/main.dart"?>
-/// <?code-excerpt "lib/main.dart"?>
-```
-
-The tool strips leading `//` or `///` prefixes before parsing the instruction.
-
----
-
-## Source File Directives: `#docregion` / `#enddocregion`
-
-Source files mark extractable regions using special directive comments.
+Source files mark extractable regions using the following `#docregion` /
+`#enddocregion` directives in comments.
 
 ### Syntax
 
+For example, in C-like languages:
+
 ```text
-// #docregion region-name
-// #enddocregion region-name
+// #docregion greetings
+void main() {
+  print('Hello, world!');
+}
+// #enddocregion greetings
 ```
 
 Multiple region names can be listed on a single directive line, separated by
@@ -143,20 +166,28 @@ commas:
 // #docregion setup, imports
 ```
 
-The directive comment prefix depends on the file type:
+The directive comment syntax depends on the source file language, for example:
 
-| File type          | Directive form        |
-| ------------------ | --------------------- |
-| Dart, JS, TS, SCSS | `// #docregion`       |
-| HTML               | `<!-- #docregion -->` |
-| CSS                | `/* #docregion */`    |
-| YAML               | `# #docregion`        |
+| File type                  | Directive form        |
+| -------------------------- | --------------------- |
+| C, C++, Dart, JS, TS, SCSS | `// #docregion`       |
+| CSS                        | `/* #docregion */`    |
+| HTML                       | `<!-- #docregion -->` |
+| YAML                       | `# #docregion`        |
 
 ### Default region
 
 A `#docregion` without a region name (or with an empty name) opens the default
-region. The entire file (minus directive lines) is also available as the default
-region even without explicit directives.
+region.
+
+If the file uses `#docregion` / `#enddocregion` but never opens that unnamed
+default explicitly, the tool may still attach default-region content from its
+full-file capture (Dart excerpt updater parity).
+
+When a file has **no** `#docregion` / `#enddocregion` lines, region extraction
+does not use a region map; a fragment PI that requests the default region then
+receives the full file with directive-looking lines removed (same idea as the
+fragment bullet above).
 
 ### Overlapping regions
 
@@ -182,7 +213,8 @@ When a region is composed of non-contiguous segments (e.g., a region opened and
 closed multiple times), a _plaster_ comment is inserted between the segments to
 indicate that content has been omitted.
 
-The default plaster text is language-specific:
+The default plaster consists of three dots (`···`) inside a language-specific
+comment, for example:
 
 | Language     | Plaster comment |
 | ------------ | --------------- |
@@ -191,5 +223,17 @@ The default plaster text is language-specific:
 | CSS, SCSS    | `/* ··· */`     |
 | YAML         | `# ···`         |
 
+Those language-shaped defaults apply when excerpt injection runs in **YAML
+excerpt mode** (`MarkdownInjectContext.excerptsYaml`); otherwise the extractor
+still inserts the raw `···` marker between segments and it is passed through
+unchanged (unless overridden or removed via `plaster`).
+
 The plaster can be overridden per-instruction with the `plaster` argument, or
 disabled entirely with `plaster="none"`.
+
+## Acknowledgments
+
+This specification was originally adapted from the
+[`chalin/code_excerpt_updater`][] README, which is the canonical reference.
+
+[`chalin/code_excerpt_updater`]: https://github.com/chalin/code_excerpt_updater

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -191,23 +191,56 @@ function escapeNgLine(line: string, enabled: boolean): string {
   return line.replace(/\{\{|\}\}/g, (m) => (m === "{{" ? "{!{" : "}!}"));
 }
 
+/**
+ * Comment delimiters around the plaster marker. Omit `end` for a line
+ * comment (start, space, then marker).
+ */
+interface PlasterCommentDelims {
+  start: string;
+  end?: string;
+}
+
+/** Fence / file language id → comment delimiters for default plaster. */
+const PLASTER_COMMENT_DELIMS_BY_LANG = new Map<string, PlasterCommentDelims>([
+  ["cpp", { start: "//" }],
+  ["cs", { start: "//" }],
+  ["csharp", { start: "//" }],
+  ["css", { start: "/*", end: "*/" }],
+  ["dart", { start: "//" }],
+  ["erlang", { start: "%" }],
+  ["go", { start: "//" }],
+  ["html", { start: "<!--", end: "-->" }],
+  ["java", { start: "//" }],
+  ["javascript", { start: "//" }],
+  ["js", { start: "//" }],
+  ["kt", { start: "//" }],
+  ["kotlin", { start: "//" }],
+  ["php", { start: "//" }],
+  ["py", { start: "#" }],
+  ["python", { start: "#" }],
+  ["rb", { start: "#" }],
+  ["rs", { start: "//" }],
+  ["ruby", { start: "#" }],
+  ["rust", { start: "//" }],
+  ["scss", { start: "/*", end: "*/" }],
+  ["swift", { start: "//" }],
+  ["ts", { start: "//" }],
+  ["typescript", { start: "//" }],
+  ["yaml", { start: "#" }],
+  ["yml", { start: "#" }],
+]);
+
+function formatPlasterWithDelims(
+  marker: string,
+  d: PlasterCommentDelims,
+): string {
+  return [d.start, marker, ...(d.end ? [d.end] : [])].join(" ");
+}
+
 function plasterTemplateForLang(lang: string): string | null {
-  switch (lang) {
-    case "css":
-    case "scss":
-      return `/* ${DEFAULT_PLASTER} */`;
-    case "html":
-      return `<!-- ${DEFAULT_PLASTER} -->`;
-    case "dart":
-    case "js":
-    case "ts":
-      return `// ${DEFAULT_PLASTER}`;
-    case "yaml":
-    case "yml":
-      return `# ${DEFAULT_PLASTER}`;
-    default:
-      return null;
-  }
+  const d = PLASTER_COMMENT_DELIMS_BY_LANG.get(lang.toLowerCase());
+  if (d === undefined) return null;
+  return formatPlasterWithDelims(DEFAULT_PLASTER, d);
 }
 
 /**

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -7,33 +7,9 @@ import {
   getExcerptRegionLines,
   maxUnindent,
 } from "../src/extract.js";
+import { dedent } from "./helpers/dedent.js";
 
 const uri = "foo";
-
-/**
- * Tagged template helper: strips the leading newline, removes the common
- * indentation of all non-blank lines, and removes trailing blank lines.
- * Allows multi-line test content to be indented naturally in source, mirroring
- * the Dart triple-quoted string style.
- */
-function dedent(strings: TemplateStringsArray, ...values: unknown[]): string {
-  let raw = strings[0] ?? "";
-  for (let i = 0; i < values.length; i++)
-    raw += String(values[i]) + (strings[i + 1] ?? "");
-  const noLeading = raw.startsWith("\n") ? raw.slice(1) : raw;
-  const lines = noLeading.split("\n");
-  while (lines.length > 0 && /^\s*$/.test(lines[lines.length - 1])) lines.pop();
-  let minIndent = Number.POSITIVE_INFINITY;
-  for (const l of lines) {
-    if (l.trim() !== "") {
-      const indent = l.length - l.trimStart().length;
-      if (indent < minIndent) minIndent = indent;
-    }
-  }
-  if (minIndent === 0 || minIndent === Number.POSITIVE_INFINITY)
-    return lines.join("\n");
-  return lines.map((l) => l.slice(minIndent)).join("\n");
-}
 
 /**
  * Returns the non-directive lines of `content` (split on `\n`), with trailing

--- a/test/helpers/dedent.ts
+++ b/test/helpers/dedent.ts
@@ -1,0 +1,27 @@
+/**
+ * Tagged template helper: strips the leading newline, removes the common
+ * indentation of all non-blank lines, and removes trailing blank lines.
+ * Allows multi-line test content to be indented naturally in source, mirroring
+ * the Dart triple-quoted string style.
+ */
+export function dedent(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string {
+  let raw = strings[0] ?? "";
+  for (let i = 0; i < values.length; i++)
+    raw += String(values[i]) + (strings[i + 1] ?? "");
+  const noLeading = raw.startsWith("\n") ? raw.slice(1) : raw;
+  const lines = noLeading.split("\n");
+  while (lines.length > 0 && /^\s*$/.test(lines[lines.length - 1])) lines.pop();
+  let minIndent = Number.POSITIVE_INFINITY;
+  for (const l of lines) {
+    if (l.trim() !== "") {
+      const indent = l.length - l.trimStart().length;
+      if (indent < minIndent) minIndent = indent;
+    }
+  }
+  if (minIndent === 0 || minIndent === Number.POSITIVE_INFINITY)
+    return lines.join("\n");
+  return lines.map((l) => l.slice(minIndent)).join("\n");
+}

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -4,6 +4,9 @@
 import { expect } from "vitest";
 import type { Directive } from "../../src/directive.js";
 
+export { dedent } from "./dedent.js";
+export { re } from "./re.js";
+
 /** Runtime check via Vitest; narrows `d` for TypeScript after the call. */
 export function expectDirective(d: Directive | null): asserts d is Directive {
   expect(d).not.toBeNull();

--- a/test/helpers/re.ts
+++ b/test/helpers/re.ts
@@ -1,0 +1,10 @@
+/**
+ * Tagged template: builds a `RegExp` from a raw pattern (equivalent to
+ * wrapping `String.raw` with `new RegExp(...)`).
+ */
+export function re(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): RegExp {
+  return new RegExp(String.raw(strings, ...values));
+}

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -4,6 +4,8 @@ import {
   PROC_INSTR_RE,
   type MarkdownInjectContext,
 } from "../src/inject.js";
+import { dedent } from "./helpers/dedent.js";
+import { re } from "./helpers/re.js";
 
 function ctx(files: Record<string, string>, base = ""): MarkdownInjectContext {
   return {
@@ -500,9 +502,57 @@ after
       const fence = out.match(/```dart[\s\S]*?```/)?.[0] ?? "";
       expect(fence).toContain("before");
       expect(fence).toContain("after");
-      expect(fence).toMatch(/\/\/\s+···/);
+      expect(fence).toMatch(re`//\s+···`);
       expect(fence).not.toMatch(/\n···\n/);
     });
+
+    it.each([
+      // Plaster line: comment start + whitespace + DEFAULT_PLASTER (···)
+      ["python", re`#\s+···`],
+      ["py", re`#\s+···`],
+      ["ruby", re`#\s+···`],
+      ["rb", re`#\s+···`],
+      ["erlang", re`%\s+···`],
+      ["go", re`//\s+···`],
+      ["rust", re`//\s+···`],
+      ["rs", re`//\s+···`],
+      ["cpp", re`//\s+···`],
+      ["csharp", re`//\s+···`],
+      ["cs", re`//\s+···`],
+      ["javascript", re`//\s+···`],
+      ["typescript", re`//\s+···`],
+      ["kotlin", re`//\s+···`],
+      ["kt", re`//\s+···`],
+      ["java", re`//\s+···`],
+      ["php", re`//\s+···`],
+      ["swift", re`//\s+···`],
+    ] as const)(
+      "substitutes plaster for excerptsYaml with %s fence",
+      (lang, pattern) => {
+        const src = dedent`
+          // #docregion
+          x
+          // #enddocregion
+          // #docregion
+          y
+          // #enddocregion
+        `;
+        const md = dedent`
+          <?code-excerpt "snippet.txt"?>
+
+          \`\`\`${lang}
+          .
+          \`\`\`
+        `;
+        const out = injectMarkdown(md, {
+          readFile: (p) => (p === "snippet.txt" ? src : null),
+          excerptsYaml: true,
+        });
+        const fence =
+          out.match(new RegExp("```" + lang + "[\\s\\S]*?```"))?.[0] ?? "";
+        expect(fence).toMatch(pattern);
+      },
+    );
 
     it("strips DEFAULT_PLASTER lines when plaster=none with excerptsYaml", () => {
       const src = `// #docregion


### PR DESCRIPTION
- Expands default plaster comment templates for additional fenced-code language identifiers (`javascript`, `typescript`, `csharp`, `cs`, Go, Kotlin, Erlang, Python, Ruby, Rust, …) via a single delimiter map in `inject.ts`.
- Extends Vitest coverage for YAML-excerpt plaster behavior across those fence ids.
- Extracts shared test helpers `dedent` and `re` (tagged template → `RegExp`) under `test/helpers/`.
- Updates `docs/spec.md` and `docs/plan.md` for accuracy, brevity, and follow-up notes (non-`.md` targets, PI / fence prefixes).
- Updates `.cspell.yml` for new language tokens used in docs and tests.