### PR TITLE
feat: tilde fences, fence-kind matching; docs and test hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,19 @@ The format is based on [Keep a Changelog][], and this project adheres to
 - CLI **`--version`**, reporting `version` from `package.json`.
 - Plaster templates for common fenced-code language identifiers, including
   `javascript`, `typescript`, `csharp`, `cs`, and more.
+- [Markdown input assumptions](docs/spec.md#markdown-input-assumptions).
+- **Tilde (`~~~`) code fences** in markdown: recognized as opening/closing
+  fences and paired by fence **kind** (backtick vs tilde vs Liquid prettify),
+  consistent with backtick and prettify blocks.
+- Unit tests for the `dedent` test helper (`test/dedent.test.ts`).
 
 ### Changed
 
 - Development `package.json` version set to **0.2.0-dev** after the **0.1.0**
   npm release.
 - README: improved installation instructions and Overview wording.
+- Refactored `inject.test.ts` to use `dedent` helper for better test readability
+  and maintainability.
 
 ## [v0.1.0][] - 2026-04-13
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,12 +79,16 @@ regex back-reference semantics (`$1`, `$2`), so this is a straightforward port.
 Parses `<?code-excerpt?>` processing instructions in markdown files and
 orchestrates the extraction + transform pipeline for each code block.
 
+- **Input assumption:** processing is line-oriented with regex-based fence
+  matching, not a full Markdown parse. Callers should supply well-formed excerpt
+  blocks; see [Markdown input assumptions](spec.md#markdown-input-assumptions).
 - Identifies `<?code-excerpt "path/file.ext (region)" arg="val" ...?>` lines.
 - Supports set instructions (`<?code-excerpt path-base="..."?>`).
 - Handles comment-prefixed instructions (`//` or `///` before
   `<?code-excerpt?>`).
 - Blank lines between an instruction and the opening fence are copied to the
   output then skipped so the fence is recognized (common in authored markdown).
+  Fenced blocks may use **backticks** (` ``` `) or **tildes** (`~~~`).
 - File-level set `replace` and optional programmatic `globalReplace` on the
   inject context compose on the joined excerpt string after per-instruction
   transforms (Dart `Updater` `fileAndCmdLineCodeTransformer` order).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3,6 +3,7 @@
 This document specifies:
 
 - `<?code-excerpt?>` processing instruction syntax and semantics
+- [Markdown input assumptions](#markdown-input-assumptions)
 - [Instruction and fence prefixes](#instruction-and-fence-prefixes)
 - [Source file directives](#source-file-directives): `#docregion` /
   `#enddocregion`
@@ -17,6 +18,21 @@ instructions** (PIs) of the form `<?code-excerpt?>`. PIs identify the source
 file, region, and transforms to apply to the code excerpt, allowing for
 `code-excerpter` to refresh code blocks when their originating source code
 changes.
+
+## Markdown input assumptions
+
+The `code-excerpter` tool is a simple line-oriented scanner, not a full Markdown
+parser. It scans lines for processing instructions and fenced blocks with
+regex-based rules. Inputs are assumed to be well-formed Markdown with processing
+instructions.
+
+After a fragment instruction, the next non-empty line should be an opening
+fence, and a matching close fence of the same kind should appear before the next
+excerpt block. Malformed nesting, unbalanced fences, or excerpts embedded in
+contexts where those lines are not real fences (for example inside indented code
+blocks) are not modeled. Some cases surface as errors; others may parse
+incorrectly without a Markdown-aware error. Behavior can diverge from a
+spec-compliant Markdown implementation.
 
 ## Instruction Forms
 

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -49,11 +49,23 @@ interface ParsedNamedArgs {
   keyOrder: string[];
 }
 
-/** Backtick fences or Liquid `{% prettify ... %}` only (not arbitrary `{% ... %}` tags). */
-const CODE_BLOCK_START = /^\s*(?:\/\/\/?)?\s*(```|{%-?\s*prettify(\s+.*)?-?%})/;
-const CODE_BLOCK_END = /^\s*(?:\/\/\/?)?\s*(```)/;
-const CODE_BLOCK_END_PRETTIFY =
-  /^\s*(?:\/\/\/?)?\s*({%-?\s*endprettify\s*-?%})/;
+// TODO: bring in x`` string template / regex helper
+
+/** Backtick fences, tilde fences, or Liquid `{% prettify ... %}` (not arbitrary `{% ... %}`). */
+const CODE_BLOCK_START =
+  /^\s*(?:\/\/\/?)?\s*(```|~~~|{%-?\s*prettify(\s+.*)?-?%})/;
+
+/** Matches any code-block closing fence (backtick, tilde, or prettify). */
+const CODE_BLOCK_END = /^\s*(?:\/\/\/?)?\s*(```|~~~|{%-?\s*endprettify\s*-?%})/;
+
+type FenceKind = "backtick" | "tilde" | "prettify";
+
+/** Classify an open or close fence token by kind. */
+function fenceKind(token: string): FenceKind {
+  if (token.startsWith("`")) return "backtick";
+  if (token.startsWith("~")) return "tilde";
+  return "prettify";
+}
 
 const REGION_IN_PATH = /\s*\((.+)\)\s*$/;
 const NON_WORD = /[^\w]+/g;
@@ -180,7 +192,7 @@ function parsePathAndRegion(unnamed: string): { path: string; region: string } {
 }
 
 function codeLang(openingFenceLine: string, path: string): string {
-  const fence = /(?:```|prettify\s+)(\w+)/.exec(openingFenceLine);
+  const fence = /(?:```|~~~|prettify\s+)(\w+)/.exec(openingFenceLine);
   if (fence !== null) return fence[1];
   return fileExtensionLower(path);
 }
@@ -293,13 +305,12 @@ function consumeFenceBlock(queue: string[]): {
   if (openMatch === null || openMatch[1] === undefined) {
     return { closed: false, lines: [opening] };
   }
-  const useBacktickEnd = openMatch[1].startsWith("`");
-  const endRe = useBacktickEnd ? CODE_BLOCK_END : CODE_BLOCK_END_PRETTIFY;
+  const openKind = fenceKind(openMatch[1]);
   const inner: string[] = [];
   while (queue.length > 0) {
     const line = queue[0]!;
-    const em = endRe.exec(line);
-    if (em?.[1]) {
+    const em = CODE_BLOCK_END.exec(line);
+    if (em?.[1] && fenceKind(em[1]) === openKind) {
       queue.shift();
       return { closed: true, lines: [opening, ...inner, line] };
     }
@@ -310,8 +321,8 @@ function consumeFenceBlock(queue: string[]): {
 
 /**
  * Updates markdown in memory: each `<?code-excerpt ...?>` followed by a fenced
- * (backtick) or Liquid `{% prettify %}` code block is replaced with freshly extracted
- * (and transformed) lines.
+ * code block (Markdown **```** or **~~~**, or Liquid `{% prettify %}`) is
+ * replaced with freshly extracted (and transformed) lines.
  */
 export function injectMarkdown(
   markdown: string,

--- a/test/cli.integration.test.ts
+++ b/test/cli.integration.test.ts
@@ -15,6 +15,7 @@ import {
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { dedent } from "./helpers/index.js";
 
 const repoRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
 const TMP_ROOT = join(repoRoot, "tmp");
@@ -117,17 +118,21 @@ describe("CLI (integration)", () => {
     mkdirSync(docs, { recursive: true });
     writeFileSync(
       join(src, "a.dart"),
-      "// #docregion\nNEW\n// #enddocregion\n",
+      dedent`
+        // #docregion
+        NEW
+        // #enddocregion
+      `,
       "utf8",
     );
-    const md = [
-      '<?code-excerpt "a.dart"?>',
-      "",
-      "```dart",
-      "OLD",
-      "```",
-      "",
-    ].join("\n");
+    const md = dedent`
+      <?code-excerpt "a.dart"?>
+
+      \`\`\`dart
+      OLD
+      \`\`\`
+
+    `;
     const mdPath = join(docs, "page.md");
     writeFileSync(mdPath, md, "utf8");
 

--- a/test/dedent.test.ts
+++ b/test/dedent.test.ts
@@ -1,0 +1,74 @@
+/** @file Unit tests for `dedent` — @see `./helpers/dedent.ts`. */
+
+import { describe, expect, it } from "vitest";
+import { dedent } from "./helpers/dedent.js";
+
+describe("dedent", () => {
+  it("strips the first character when it is a newline", () => {
+    expect(dedent`\na`).toBe("a");
+    expect(dedent`
+      a`).toBe("a");
+  });
+
+  it("removes common leading indentation from non-blank lines", () => {
+    expect(
+      dedent`
+        alpha
+        beta
+      `,
+    ).toBe("alpha\nbeta");
+  });
+
+  it("drops trailing whitespace-only lines", () => {
+    expect(
+      dedent`
+        x
+        
+      `,
+    ).toBe("x");
+  });
+
+  it("does not use blank lines for minimum-indent calculation", () => {
+    expect(
+      dedent`
+        a
+
+        b
+      `,
+    ).toBe("a\n\nb");
+  });
+
+  it("leaves lines unchanged when minimum indent is 0", () => {
+    expect(dedent`no-indent`).toBe("no-indent");
+    expect(
+      dedent`
+mixed
+  indented`,
+    ).toBe("mixed\n  indented");
+  });
+
+  it("interpolates values", () => {
+    const n = 2;
+    expect(dedent`line ${n}`).toBe("line 2");
+    expect(
+      dedent`
+        ${"x"}
+        y
+      `,
+    ).toBe("x\ny");
+  });
+
+  it("returns empty string for empty or whitespace-only template", () => {
+    expect(dedent``).toBe("");
+    expect(dedent`\n`).toBe("");
+  });
+
+  it("preserves leading spaces when they exceed common indent", () => {
+    expect(
+      dedent`
+        outer
+          inner
+      `,
+    ).toBe("outer\n  inner");
+  });
+});

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -1,3 +1,9 @@
+/** @file Tests for the `injectMarkdown` function.
+ * @see `src/inject.ts`
+ *
+ * cSpell:ignore mundo
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import {
   injectMarkdown,
@@ -5,7 +11,6 @@ import {
   type MarkdownInjectContext,
 } from "../src/inject.js";
 import { dedent } from "./helpers/dedent.js";
-import { re } from "./helpers/re.js";
 
 function ctx(files: Record<string, string>, base = ""): MarkdownInjectContext {
   return {
@@ -13,6 +18,28 @@ function ctx(files: Record<string, string>, base = ""): MarkdownInjectContext {
     pathBase: base,
   };
 }
+
+/** Expected plaster separator line inside ` ```lang ` fences for `it.each` plaster tests. */
+const PLASTER_LINE_BY_FENCE_LANG: Record<string, string> = {
+  python: "# ···",
+  py: "# ···",
+  ruby: "# ···",
+  rb: "# ···",
+  erlang: "% ···",
+  go: "// ···",
+  rust: "// ···",
+  rs: "// ···",
+  cpp: "// ···",
+  csharp: "// ···",
+  cs: "// ···",
+  javascript: "// ···",
+  typescript: "// ···",
+  kotlin: "// ···",
+  kt: "// ···",
+  java: "// ···",
+  php: "// ···",
+  swift: "// ···",
+};
 
 describe("inject", () => {
   describe("PROC_INSTR_RE", () => {
@@ -44,50 +71,126 @@ describe("inject", () => {
 
   describe("injectMarkdown", () => {
     it("injects default region from dart source", () => {
-      const src = `// #docregion
-final x = 1;
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt "lib/a.dart"?>',
-        "",
-        "```dart",
-        "old",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        final x = 1;
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "lib/a.dart"?>
+
+        \`\`\`dart
+        old
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "lib/a.dart": src }));
-      expect(out).toContain("final x = 1;");
-      expect(out).not.toContain("old");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "lib/a.dart"?>
+
+        \`\`\`dart
+        final x = 1;
+        \`\`\`
+
+      `);
+    });
+
+    it("injects through tilde markdown fences", () => {
+      const src = dedent`
+        // #docregion
+        tilde-body
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "tilde.dart"?>
+
+        ~~~dart
+        old
+        ~~~
+
+      `;
+      const out = injectMarkdown(md, ctx({ "tilde.dart": src }));
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "tilde.dart"?>
+
+        ~~~dart
+        tilde-body
+        ~~~
+      `);
+    });
+
+    it("injects excerpt containing nested markdown code fences when outer fence is tilde", () => {
+      // Outer `~~~` is required so inner ``` lines are not mistaken for the
+      // closing fence (fence-end matching is by kind: backtick vs tilde).
+      const src = dedent`
+        # Section
+
+        \`\`\`dart
+        const injected = 42;
+        \`\`\`
+
+        Trailing prose.
+      `;
+      const md = dedent`
+        <?code-excerpt "nested-fences.md"?>
+
+        ~~~markdown
+        old-placeholder
+        ~~~
+
+      `;
+      const expected = dedent`
+        <?code-excerpt "nested-fences.md"?>
+
+        ~~~markdown
+        # Section
+
+        \`\`\`dart
+        const injected = 42;
+        \`\`\`
+
+        Trailing prose.
+        ~~~
+      `;
+      const out = injectMarkdown(md, ctx({ "nested-fences.md": src }));
+      expect(out).toStrictEqual(expected);
     });
 
     it("applies path-base before resolving path", () => {
       const src = "// ok\n";
-      const md = [
-        '<?code-excerpt path-base="p"?>',
-        '<?code-excerpt "b.dart"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt path-base="p"?>
+        <?code-excerpt "b.dart"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "p/b.dart": src }));
-      expect(out).toContain("// ok");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt path-base="p"?>
+        <?code-excerpt "b.dart"?>
+
+        \`\`\`
+        // ok
+        \`\`\`
+
+      `);
     });
 
     it("increments instructionStats for parsed set and fragment directives", () => {
       const instructionStats = { set: 0, fragment: 0 };
       const src = "// ok\n";
-      const md = [
-        '<?code-excerpt path-base="p"?>',
-        '<?code-excerpt "b.dart"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt path-base="p"?>
+        <?code-excerpt "b.dart"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       injectMarkdown(md, {
         ...ctx({ "p/b.dart": src }),
         instructionStats,
@@ -97,130 +200,165 @@ final x = 1;
     });
 
     it("applies skip transform", () => {
-      const src = `// #docregion
-a
-b
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt "f.dart" skip="1"?>',
-        "",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        a
+        b
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "f.dart" skip="1"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "f.dart": src }));
-      const fence = out.match(/```[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("b");
-      expect(fence).not.toContain("a");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "f.dart" skip="1"?>
+
+        \`\`\`
+        b
+        \`\`\`
+
+      `);
     });
 
     it("strips list marker prefix in linePrefix", () => {
-      const src = `// #docregion
-z
-// #enddocregion
-`;
-      const md = [
-        '- <?code-excerpt "x.dart"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        z
+        // #enddocregion
+      `;
+      const md = dedent`
+        - <?code-excerpt "x.dart"?>
+
+          \`\`\`
+          .
+          \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "x.dart": src }));
-      expect(out).toMatch(/^\s+z$/m);
+      expect(out).toStrictEqual(dedent`
+        - <?code-excerpt "x.dart"?>
+
+          \`\`\`
+          z
+          \`\`\`
+
+      `);
     });
 
     it("returns original block when source is missing", () => {
       const onError = vi.fn();
-      const md = [
-        '<?code-excerpt "missing.dart"?>',
-        "",
-        "```",
-        "keep",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt "missing.dart"?>
+
+        \`\`\`
+        keep
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, { readFile: () => null, onError });
-      expect(out).toContain("keep");
+      expect(out).toStrictEqual(md);
       expect(onError).toHaveBeenCalled();
     });
 
     it("leaves block unchanged for diff-with with error", () => {
       const onError = vi.fn();
-      const md = [
-        '<?code-excerpt "a.dart" diff-with="b.dart"?>',
-        "",
-        "```",
-        "old",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt "a.dart" diff-with="b.dart"?>
+
+        \`\`\`
+        old
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: () => "//\n",
         onError,
       });
-      expect(out).toContain("old");
+      expect(out).toStrictEqual(md);
       expect(onError).toHaveBeenCalled();
     });
 
     it("reads implicit default region when file has no directives", () => {
       const src = "plain line\n";
-      const md = [
-        '<?code-excerpt "plain.txt"?>',
-        "",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt "plain.txt"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "plain.txt": src }));
-      expect(out).toContain("plain line");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "plain.txt"?>
+
+        \`\`\`
+        plain line
+        \`\`\`
+
+      `);
     });
 
     it("applies file-level set replace after excerpt transforms", () => {
-      const src = `// #docregion
-SRC_TOKEN
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt replace="/SRC_TOKEN/NEW/g"?>',
-        '<?code-excerpt "r.dart"?>',
-        "",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        SRC_TOKEN
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt replace="/SRC_TOKEN/NEW/g"?>
+        <?code-excerpt "r.dart"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "r.dart": src }));
-      const fence = out.match(/```[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("NEW");
-      expect(fence).not.toContain("SRC_TOKEN");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt replace="/SRC_TOKEN/NEW/g"?>
+        <?code-excerpt "r.dart"?>
+
+        \`\`\`
+        NEW
+        \`\`\`
+
+      `);
     });
 
     it("applies globalReplace from context after file-level replace", () => {
-      const src = `// #docregion
-aa
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt replace="/aa/bb/g"?>',
-        '<?code-excerpt "g.dart"?>',
-        "",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        aa
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt replace="/aa/bb/g"?>
+        <?code-excerpt "g.dart"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "g.dart" ? src : null),
         globalReplace: `/bb/cc/g`,
       });
-      const fence = out.match(/```[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("cc");
-      expect(fence).not.toContain("aa");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt replace="/aa/bb/g"?>
+        <?code-excerpt "g.dart"?>
+
+        \`\`\`
+        cc
+        \`\`\`
+
+      `);
     });
 
     it("throws on invalid globalReplace", () => {
@@ -235,7 +373,15 @@ aa
     it("reports invalid processing instruction when regex does not match", () => {
       const onError = vi.fn();
       const bad = '<?code-excerpt "broken.dart skip="1"?>';
-      injectMarkdown(`${bad}\n\`\`\`\nx\n\`\`\`\n`, {
+      const md = dedent`
+        ${bad}
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
+      injectMarkdown(md, {
         readFile: () => "//\n",
         onError,
       });
@@ -247,34 +393,46 @@ aa
     it("warns when text follows ?> on the same line and does not inject", () => {
       const onWarning = vi.fn();
       const onError = vi.fn();
-      const src = `// #docregion\nNEVER\n// #enddocregion\n`;
-      const md = [
-        '<?code-excerpt "t.dart"?> trailing junk',
-        "",
-        "```",
-        "KEEP",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        NEVER
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "t.dart"?> trailing junk
+
+        \`\`\`
+        KEEP
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "t.dart" ? src : null),
         onWarning,
         onError,
       });
+      expect(out).toStrictEqual(md);
       expect(onWarning).toHaveBeenCalledWith(
         expect.stringContaining('extraneous text after closing "?>"'),
       );
       expect(onError).not.toHaveBeenCalled();
-      expect(out).toContain("KEEP");
-      expect(out).not.toContain("NEVER");
     });
 
     it("warns when PI is not closed with ?>", () => {
       const onWarning = vi.fn();
-      const src = `// #docregion\nok\n// #enddocregion\n`;
-      const md = ['<?code-excerpt "c.dart">', "", "```", "x", "```", ""].join(
-        "\n",
-      );
+      const src = dedent`
+        // #docregion
+        ok
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "c.dart">
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       injectMarkdown(md, {
         readFile: (p) => (p === "c.dart" ? src : null),
         onWarning,
@@ -286,54 +444,60 @@ aa
 
     it("errors on unterminated markdown fence and keeps original block", () => {
       const onError = vi.fn();
-      const src = `// #docregion\nNOT_INJECTED\n// #enddocregion\n`;
-      const md = ['<?code-excerpt "u.dart"?>', "", "```", "keep-inner"].join(
-        "\n",
-      );
+      const src = dedent`
+        // #docregion
+        NOT_INJECTED
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "u.dart"?>
+
+        \`\`\`
+        keep-inner
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "u.dart" ? src : null),
         onError,
       });
+      expect(out).toStrictEqual(md);
       expect(onError).toHaveBeenCalledWith(
         expect.stringContaining("unterminated markdown code block"),
       );
-      expect(out).toContain("keep-inner");
-      expect(out).not.toContain("NOT_INJECTED");
     });
 
     it("errors when code block does not immediately follow excerpt PI", () => {
       const onError = vi.fn();
       const src = "//\n";
-      const md = [
-        '<?code-excerpt "q.dart"?>',
-        "",
-        "int x = 0;",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt "q.dart"?>
+
+        int x = 0;
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "q.dart" ? src : null),
         onError,
       });
+      expect(out).toStrictEqual(md);
       expect(onError).toHaveBeenCalledWith(
         expect.stringMatching(/code block should immediately follow/s),
       );
-      expect(out).toContain("int x = 0;");
     });
 
     it("errors on set instruction with more than one argument", () => {
       const onError = vi.fn();
-      const md = [
-        '<?code-excerpt path-base="a" replace="/x/y/g"?>',
-        '<?code-excerpt "b.dart"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt path-base="a" replace="/x/y/g"?>
+        <?code-excerpt "b.dart"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       injectMarkdown(md, {
         readFile: () => "//\n",
         onError,
@@ -345,15 +509,15 @@ aa
 
     it("warns and ignores unrecognized set instruction argument", () => {
       const onWarning = vi.fn();
-      const md = [
-        '<?code-excerpt foo="abc"?>',
-        '<?code-excerpt "z.dart"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const md = dedent`
+        <?code-excerpt foo="abc"?>
+        <?code-excerpt "z.dart"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       injectMarkdown(md, {
         readFile: () => "//\n",
         onWarning,
@@ -364,171 +528,239 @@ aa
     });
 
     it("clears file-level replace when set replace is empty", () => {
-      const src = `// #docregion\nSRC_TOKEN\n// #enddocregion\n`;
-      const md = [
-        '<?code-excerpt replace="/SRC_TOKEN/NEW/g"?>',
-        '<?code-excerpt replace=""?>',
-        '<?code-excerpt "clr.dart"?>',
-        "",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        SRC_TOKEN
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt replace="/SRC_TOKEN/NEW/g"?>
+        <?code-excerpt replace=""?>
+        <?code-excerpt "clr.dart"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "clr.dart": src }));
-      const fence = out.match(/```[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("SRC_TOKEN");
-      expect(fence).not.toContain("NEW");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt replace="/SRC_TOKEN/NEW/g"?>
+        <?code-excerpt replace=""?>
+        <?code-excerpt "clr.dart"?>
+
+        \`\`\`
+        SRC_TOKEN
+        \`\`\`
+
+      `);
     });
 
     it("does not apply invalid file-level set replace (reports error)", () => {
       const onError = vi.fn();
-      const src = `// #docregion\nSRC_TOKEN\n// #enddocregion\n`;
-      const md = [
-        '<?code-excerpt replace="not-a-regex-pipeline"?>',
-        '<?code-excerpt "inv.dart"?>',
-        "",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        SRC_TOKEN
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt replace="not-a-regex-pipeline"?>
+        <?code-excerpt "inv.dart"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "inv.dart" ? src : null),
         onError,
       });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt replace="not-a-regex-pipeline"?>
+        <?code-excerpt "inv.dart"?>
+
+        \`\`\`
+        SRC_TOKEN
+        \`\`\`
+
+      `);
       expect(onError).toHaveBeenCalledWith(
         expect.stringMatching(/invalid replace attribute/),
       );
-      const fence = out.match(/```[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("SRC_TOKEN");
     });
 
     it("applies globalReplace without file-level set replace", () => {
-      const src = `// #docregion\nhello\n// #enddocregion\n`;
-      const md = [
-        '<?code-excerpt "only-gr.dart"?>',
-        "",
-        "```",
-        "x",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        hello
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "only-gr.dart"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "only-gr.dart" ? src : null),
         globalReplace: `/hello/mundo/g`,
       });
-      const fence = out.match(/```[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("mundo");
-      expect(fence).not.toContain("hello");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "only-gr.dart"?>
+
+        \`\`\`
+        mundo
+        \`\`\`
+
+      `);
     });
 
     it("treats set class-only and title-only as no-ops (no warning)", () => {
       const onWarning = vi.fn();
-      const src = `// #docregion\nok\n// #enddocregion\n`;
-      const md = [
-        '<?code-excerpt class="prettyprint"?>',
-        '<?code-excerpt title="Sample"?>',
-        '<?code-excerpt "noop.dart"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        ok
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt class="prettyprint"?>
+        <?code-excerpt title="Sample"?>
+        <?code-excerpt "noop.dart"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "noop.dart" ? src : null),
         onWarning,
       });
       expect(onWarning).not.toHaveBeenCalled();
-      expect(out).toContain("ok");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt class="prettyprint"?>
+        <?code-excerpt title="Sample"?>
+        <?code-excerpt "noop.dart"?>
+
+        \`\`\`
+        ok
+        \`\`\`
+
+      `);
     });
 
     it("uses region= named argument when path has no (region) suffix", () => {
-      const src = `// #docregion r1\nin-r1\n// #enddocregion\n`;
-      const md = [
-        '<?code-excerpt "reg.dart" region="r1"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion r1
+        in-r1
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "reg.dart" region="r1"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "reg.dart": src }));
-      expect(out).toContain("in-r1");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "reg.dart" region="r1"?>
+
+        \`\`\`
+        in-r1
+        \`\`\`
+
+      `);
     });
 
     it('region="" overrides path-embedded (region) and returns full file', () => {
-      const src = [
-        "// #docregion greeting",
-        "var greeting = 'hello';",
-        "// #enddocregion greeting",
-        "",
-        "void main() {}",
-      ].join("\n");
-      const md = [
-        '<?code-excerpt "a.dart (greeting)" region=""?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion greeting
+        var greeting = 'hello';
+        // #enddocregion greeting
+
+        void main() {}
+      `;
+      const md = dedent`
+        <?code-excerpt "a.dart (greeting)" region=""?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "a.dart": src }));
-      expect(out).toContain("var greeting");
-      expect(out).toContain("void main()");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "a.dart (greeting)" region=""?>
+
+        \`\`\`
+        var greeting = 'hello';
+
+        void main() {}
+        \`\`\`
+
+      `);
     });
 
     it("substitutes plaster markers when excerptsYaml is true", () => {
-      const src = `// #docregion
-before
-// #enddocregion
-// #docregion
-after
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt "pl.dart"?>',
-        "",
-        "```dart",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        before
+        // #enddocregion
+        // #docregion
+        after
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "pl.dart"?>
+
+        \`\`\`dart
+        .
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "pl.dart" ? src : null),
         excerptsYaml: true,
       });
-      const fence = out.match(/```dart[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("before");
-      expect(fence).toContain("after");
-      expect(fence).toMatch(re`//\s+···`);
-      expect(fence).not.toMatch(/\n···\n/);
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "pl.dart"?>
+
+        \`\`\`dart
+        before
+        // ···
+        after
+        \`\`\`
+
+      `);
     });
 
     it.each([
-      // Plaster line: comment start + whitespace + DEFAULT_PLASTER (···)
-      ["python", re`#\s+···`],
-      ["py", re`#\s+···`],
-      ["ruby", re`#\s+···`],
-      ["rb", re`#\s+···`],
-      ["erlang", re`%\s+···`],
-      ["go", re`//\s+···`],
-      ["rust", re`//\s+···`],
-      ["rs", re`//\s+···`],
-      ["cpp", re`//\s+···`],
-      ["csharp", re`//\s+···`],
-      ["cs", re`//\s+···`],
-      ["javascript", re`//\s+···`],
-      ["typescript", re`//\s+···`],
-      ["kotlin", re`//\s+···`],
-      ["kt", re`//\s+···`],
-      ["java", re`//\s+···`],
-      ["php", re`//\s+···`],
-      ["swift", re`//\s+···`],
+      "python",
+      "py",
+      "ruby",
+      "rb",
+      "erlang",
+      "go",
+      "rust",
+      "rs",
+      "cpp",
+      "csharp",
+      "cs",
+      "javascript",
+      "typescript",
+      "kotlin",
+      "kt",
+      "java",
+      "php",
+      "swift",
     ] as const)(
       "substitutes plaster for excerptsYaml with %s fence",
-      (lang, pattern) => {
+      (lang) => {
         const src = dedent`
           // #docregion
           x
@@ -548,42 +780,59 @@ after
           readFile: (p) => (p === "snippet.txt" ? src : null),
           excerptsYaml: true,
         });
-        const fence =
-          out.match(new RegExp("```" + lang + "[\\s\\S]*?```"))?.[0] ?? "";
-        expect(fence).toMatch(pattern);
+        const plasterLine = PLASTER_LINE_BY_FENCE_LANG[lang];
+        expect(plasterLine).toBeDefined();
+        expect(out).toStrictEqual(dedent`
+          <?code-excerpt "snippet.txt"?>
+
+          \`\`\`${lang}
+          x
+          ${plasterLine}
+          y
+          \`\`\`
+        `);
       },
     );
 
     it("strips DEFAULT_PLASTER lines when plaster=none with excerptsYaml", () => {
-      const src = `// #docregion
-a
-// #enddocregion
-// #docregion
-b
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt plaster="none"?>',
-        '<?code-excerpt "pn.dart"?>',
-        "",
-        "```dart",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        a
+        // #enddocregion
+        // #docregion
+        b
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt plaster="none"?>
+        <?code-excerpt "pn.dart"?>
+
+        \`\`\`dart
+        .
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === "pn.dart" ? src : null),
         excerptsYaml: true,
       });
-      const fence = out.match(/```dart[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("a");
-      expect(fence).toContain("b");
-      expect(fence).not.toContain("···");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt plaster="none"?>
+        <?code-excerpt "pn.dart"?>
+
+        \`\`\`dart
+        a
+        b
+        \`\`\`
+
+      `);
     });
 
     it("errors when input ends after excerpt PI (no code block)", () => {
       const onError = vi.fn();
-      const md = ['<?code-excerpt "end.dart"?>', ""].join("\n");
+      const md = dedent`
+        <?code-excerpt "end.dart"?>
+      `;
       injectMarkdown(md, {
         readFile: () => "//\n",
         onError,
@@ -594,54 +843,73 @@ b
     });
 
     it("handles liquid prettify fences like backtick fences", () => {
-      const src = `// #docregion
-liquid
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt "liq.dart"?>',
-        "",
-        "{% prettify dart %}",
-        ".",
-        "{% endprettify %}",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        liquid
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "liq.dart"?>
+
+        {% prettify dart %}
+        .
+        {% endprettify %}
+
+      `;
       const out = injectMarkdown(md, ctx({ "liq.dart": src }));
-      expect(out).toContain("liquid");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "liq.dart"?>
+
+        {% prettify dart %}
+        liquid
+        {% endprettify %}
+
+      `);
     });
 
     it("does not treat non-prettify Liquid blocks as code fences", () => {
-      const src = `// #docregion\nINJECTED\n// #enddocregion\n`;
-      const md = [
-        '<?code-excerpt "x.dart"?>',
-        "",
-        "{% if true %}",
-        "SHOULD_STAY",
-        "{% endif %}",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        INJECTED
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "x.dart"?>
+
+        {% if true %}
+        SHOULD_STAY
+        {% endif %}
+
+      `;
       const out = injectMarkdown(md, ctx({ "x.dart": src }));
-      expect(out).toContain("SHOULD_STAY");
-      expect(out).not.toContain("INJECTED");
+      expect(out).toStrictEqual(md);
     });
 
     it("chains multiple replace steps in file-level set replace", () => {
-      const src = `// #docregion
-ab
-// #enddocregion
-`;
-      const md = [
-        '<?code-excerpt replace="/a/x/g;/b/y/g"?>',
-        '<?code-excerpt "chain.dart"?>',
-        "",
-        "```",
-        ".",
-        "```",
-        "",
-      ].join("\n");
+      const src = dedent`
+        // #docregion
+        ab
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt replace="/a/x/g;/b/y/g"?>
+        <?code-excerpt "chain.dart"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
       const out = injectMarkdown(md, ctx({ "chain.dart": src }));
-      const fence = out.match(/```[\s\S]*?```/)?.[0] ?? "";
-      expect(fence).toContain("xy");
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt replace="/a/x/g;/b/y/g"?>
+        <?code-excerpt "chain.dart"?>
+
+        \`\`\`
+        xy
+        \`\`\`
+
+      `);
     });
   });
 });

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -40,7 +40,14 @@ import {
 } from "node:fs";
 import { join, relative } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import type { InstructionStats } from "../src/instructionStats.js";
 import { updatePaths } from "../src/update.js";
+
+/** Expected `instructionStats` when no set/fragment directives were parsed. */
+const ZERO_STATS: InstructionStats = { set: 0, fragment: 0 };
+
+/** Expected `instructionStats` when exactly one fragment directive was parsed. */
+const ONE_FRAGMENT: InstructionStats = { set: 0, fragment: 1 };
 
 const TMP_ROOT = join(process.cwd(), "tmp");
 const TEST_TMP_DIR_PREFIX = "ce-test";
@@ -93,6 +100,12 @@ function useTmp(): string {
   return d;
 }
 
+/** Registers a tmp dir and returns conventional `src` / `docs` subtrees. */
+function useTmpSrcDocs(): { tmp: string; src: string; docs: string } {
+  const tmp = useTmp();
+  return { tmp, src: join(tmp, "src"), docs: join(tmp, "docs") };
+}
+
 const keepTestTmp =
   process.env.KEEP_TEST_TMP === "1" || process.env.KEEP_TEST_TMP === "true";
 
@@ -107,9 +120,7 @@ afterEach(() => {
 
 describe("updatePaths", () => {
   it("updates a markdown file with an excerpt", async () => {
-    const tmp = useTmp();
-    const src = join(tmp, "src");
-    const docs = join(tmp, "docs");
+    const { src, docs } = useTmpSrcDocs();
 
     writeFixture(
       src,
@@ -139,7 +150,7 @@ describe("updatePaths", () => {
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(1);
     expect(result.errors).toEqual([]);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
+    expect(result.instructionStats).toEqual(ONE_FRAGMENT);
 
     const updated = readFileSync(join(docs, "guide.md"), "utf8");
     expect(updated).toContain("var greeting = 'hello';");
@@ -147,9 +158,7 @@ describe("updatePaths", () => {
   });
 
   it("resolves excerpts when pathBase is relative to cwd (CLI -p)", async () => {
-    const tmp = useTmp();
-    const src = join(tmp, "src");
-    const docs = join(tmp, "docs");
+    const { src, docs } = useTmpSrcDocs();
 
     writeFixture(
       src,
@@ -178,16 +187,14 @@ describe("updatePaths", () => {
 
     expect(result.errors, result.errors.join("\n")).toEqual([]);
     expect(result.filesUpdated).toBe(1);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
+    expect(result.instructionStats).toEqual(ONE_FRAGMENT);
     expect(readFileSync(join(docs, "page.md"), "utf8")).toContain(
       "const k = 42;",
     );
   });
 
   it("leaves unchanged files untouched (no write)", async () => {
-    const tmp = useTmp();
-    const src = join(tmp, "src");
-    const docs = join(tmp, "docs");
+    const { src, docs } = useTmpSrcDocs();
 
     writeFixture(
       src,
@@ -209,14 +216,12 @@ describe("updatePaths", () => {
 
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(0);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
+    expect(result.instructionStats).toEqual(ONE_FRAGMENT);
     expect(readFileSync(join(docs, "already-ok.md"), "utf8")).toBe(md);
   });
 
   it("processes multiple files in a directory tree", async () => {
-    const tmp = useTmp();
-    const src = join(tmp, "src");
-    const docs = join(tmp, "docs");
+    const { src, docs } = useTmpSrcDocs();
 
     writeFixture(src, "f.dart", "// #docregion\nA\n// #enddocregion\n");
 
@@ -248,7 +253,7 @@ describe("updatePaths", () => {
     const result = await updatePaths([docs]);
 
     expect(result.filesProcessed).toBe(1);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("respects --exclude patterns", async () => {
@@ -263,7 +268,7 @@ describe("updatePaths", () => {
     });
 
     expect(result.filesProcessed).toBe(1);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("dedupes the same root passed more than once", async () => {
@@ -272,7 +277,7 @@ describe("updatePaths", () => {
     writeFixture(docs, "a.md", "no PI\n");
     const result = await updatePaths([docs, docs]);
     expect(result.filesProcessed).toBe(1);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("dedupes overlapping roots when a subdirectory is also listed", async () => {
@@ -281,7 +286,7 @@ describe("updatePaths", () => {
     writeFixture(docs, "sub/page.md", "no PI\n");
     const result = await updatePaths([docs, join(docs, "sub")]);
     expect(result.filesProcessed).toBe(1);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("skips markdown when the sole root is a dot-prefixed directory", async () => {
@@ -293,7 +298,7 @@ describe("updatePaths", () => {
     const result = await updatePaths([root]);
 
     expect(result.filesProcessed).toBe(0);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("skips markdown when the sole root matches --exclude", async () => {
@@ -305,13 +310,11 @@ describe("updatePaths", () => {
     const result = await updatePaths([root], { exclude: [/vendor/] });
 
     expect(result.filesProcessed).toBe(0);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("dry-run does not write files", async () => {
-    const tmp = useTmp();
-    const src = join(tmp, "src");
-    const docs = join(tmp, "docs");
+    const { src, docs } = useTmpSrcDocs();
 
     writeFixture(src, "a.dart", "// #docregion\nNEW\n// #enddocregion\n");
     const original = [
@@ -330,7 +333,7 @@ describe("updatePaths", () => {
     });
 
     expect(result.filesUpdated).toBe(1);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
+    expect(result.instructionStats).toEqual(ONE_FRAGMENT);
     expect(readFileSync(join(docs, "dry.md"), "utf8")).toBe(original);
   });
 
@@ -350,7 +353,7 @@ describe("updatePaths", () => {
 
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toMatch(/cannot read source file/);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
+    expect(result.instructionStats).toEqual(ONE_FRAGMENT);
   });
 
   it("records an error when a root path does not exist", async () => {
@@ -366,7 +369,7 @@ describe("updatePaths", () => {
     expect(result.filesUpdated).toBe(0);
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toMatch(/ENOENT|no such file|not found/i);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("still processes existing roots when another root path is missing", async () => {
@@ -385,7 +388,7 @@ describe("updatePaths", () => {
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(0);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("accepts individual files as paths", async () => {
@@ -396,7 +399,7 @@ describe("updatePaths", () => {
 
     expect(result.filesProcessed).toBe(1);
     expect(result.filesUpdated).toBe(0);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("skips a dot-prefixed markdown file when passed as a single-file path", async () => {
@@ -406,7 +409,7 @@ describe("updatePaths", () => {
     const result = await updatePaths([join(tmp, ".secret.md")]);
 
     expect(result.filesProcessed).toBe(0);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   // cSpell:ignore skipme
@@ -419,7 +422,7 @@ describe("updatePaths", () => {
     });
 
     expect(result.filesProcessed).toBe(0);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("skips non-md files when given a directory", async () => {
@@ -431,13 +434,11 @@ describe("updatePaths", () => {
     const result = await updatePaths([tmp]);
 
     expect(result.filesProcessed).toBe(1);
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 0 });
+    expect(result.instructionStats).toEqual(ZERO_STATS);
   });
 
   it("passes globalReplace through to injectMarkdown", async () => {
-    const tmp = useTmp();
-    const src = join(tmp, "src");
-    const docs = join(tmp, "docs");
+    const { src, docs } = useTmpSrcDocs();
 
     writeFixture(src, "r.dart", "// #docregion\nhello\n// #enddocregion\n");
     writeFixture(
@@ -451,7 +452,7 @@ describe("updatePaths", () => {
       globalReplace: "/hello/world/g",
     });
 
-    expect(result.instructionStats).toEqual({ set: 0, fragment: 1 });
+    expect(result.instructionStats).toEqual(ONE_FRAGMENT);
     const updated = readFileSync(join(docs, "gr.md"), "utf8");
     expect(updated).toContain("world");
     expect(updated).not.toContain("hello");


### PR DESCRIPTION
- Unify CODE_BLOCK_END and fenceKind() for backtick / tilde / prettify pairing
- Extend CODE_BLOCK_START and codeLang() for ~~~
- Document Markdown input assumptions in spec; link from architecture
- Add test/dedent.test.ts; refactor inject/update/cli tests (dedent, strictEqual)