### PR TITLE
Align replace-expression semantics with JavaScript and document them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,21 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 ### Added
 
-- CLI **`--version`**, reporting `version` from `package.json`.
+- [Markdown input assumptions](docs/spec.md#markdown-input-assumptions).
 - Plaster templates for common fenced-code language identifiers, including
   `javascript`, `typescript`, `csharp`, `cs`, and more.
-- [Markdown input assumptions](docs/spec.md#markdown-input-assumptions).
 - **Tilde (`~~~`) code fences** in markdown: recognized as opening/closing
   fences and paired by fence **kind** (backtick vs tilde vs Liquid prettify),
   consistent with backtick and prettify blocks.
+- CLI **`--version`**, reporting `version` from `package.json`.
 
 ### Changed
 
 - Development `package.json` version set to **0.2.0-dev** after the **0.1.0**
   npm release.
 - README: improved installation instructions and Overview wording.
+- [`replace` expressions](docs/spec.md#replace-expressions) now features full
+  JavaScript semantics
 
 ## [v0.1.0][] - 2026-04-13
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -93,31 +93,66 @@ path string). Set instructions accept **only** `path-base`, `replace`,
 `plaster`, or no-op compatibility keys `class` / `title`—see
 [Set instruction](#set-instruction); any other set key triggers a warning.
 
-| Argument        | Type                         | Description                                                     |
-| --------------- | ---------------------------- | --------------------------------------------------------------- |
-| _(path string)_ | string                       | Positional: `"path/file.ext (region)"`                          |
-| `path-base`     | string                       | Sets the base directory for source file paths (set instruction) |
-| `region`        | string                       | Named region to extract (alternative to inline `(region)`)      |
-| `from`          | string/regex                 | Start extraction from the first line matching this pattern      |
-| `to`            | string/regex                 | End after the first line matching this pattern (that line kept) |
-| `skip`          | integer                      | Skip the first N lines of the extracted region                  |
-| `take`          | integer                      | Take only the first N lines of the extracted region             |
-| `remove`        | string/regex                 | Remove all lines matching this pattern                          |
-| `retain`        | string/regex                 | Keep only lines matching this pattern                           |
-| `replace`       | `"pattern" -> "replacement"` | Regex replace within extracted lines                            |
-| `indent-by`     | integer                      | Prepend N spaces to every output line                           |
-| `plaster`       | string                       | Override the plaster comment (use `"none"` to disable)          |
+| Argument name   | Argument values              | Description                                                           |
+| --------------- | ---------------------------- | --------------------------------------------------------------------- |
+| _(path string)_ | _string_                     | Positional: `"path/file.ext (region)"`                                |
+| `path-base`     | _string_                     | Sets the base directory for source file paths (set instruction)       |
+| `region`        | _string_                     | Named region to extract (alternative to inline `(region)`)            |
+| `from`          | _string_ \| `/regex/`        | Start extraction from the first line matching this pattern            |
+| `to`            | _string_ \| `/regex/`        | End after the first line matching this pattern (that line kept)       |
+| `skip`          | _integer_                    | Skip the first N lines of the extracted region                        |
+| `take`          | _integer_                    | Take only the first N lines of the extracted region                   |
+| `remove`        | _string_ \| `/regex/`        | Remove all lines matching this pattern                                |
+| `retain`        | _string_ \| `/regex/`        | Keep only lines matching this pattern                                 |
+| `replace`       | `/pattern/replacement/g;`... | Regex replace within extracted lines (supports multiple replacements) |
+| `indent-by`     | _integer_                    | Prepend N spaces to every output line                                 |
+| `plaster`       | _string_                     | Override the plaster comment (use `"none"` to disable)                |
 
-On a fragment, `replace` and `plaster` participate in the transform or plaster
-pass for that excerpt only. As the **sole** argument on a
+On a fragment instruction, `replace` and `plaster` participate in the transform
+or plaster pass for that excerpt only. As the **sole** argument on a
 [set instruction](#set-instruction), they set file-level defaults (`replace`
 runs on the joined excerpt after fragment transforms; `plaster` sets the
 template for later fragments, and bare `plaster` clears the file default).
 
+### Replace expressions
+
+The `replace` can be followed by a list of one or more semicolon-separated (`;`)
+Perl-like substitution expressions, but with JavaScript semantics. Each
+expression is of the form:
+
+```text
+/pattern/replacement/g
+```
+
+For example:
+
+```text
+/hello/bonjour/g;/world/mundo/g
+```
+
+Each **replacement** string uses the same rules as [String.replace()][] with a
+string replacer.
+
+- `$$` → literal `$`; `$&` → full match; `` $` `` → text before the match; `$'`
+  → text after the match.
+- `$1`–`$99` → numbered captures when valid (two-digit indices use ECMA’s
+  two-then-one-digit rule, e.g. one group and `$10` → group `1` plus literal
+  `0`). If the index is missing or out of range, the `$…` sequence is kept
+  literally (e.g. no parens → `$1` stays `$1`).
+- `$` followed only by `0` digits (e.g. `$0`, `$00`) → those characters
+  literally, not a “group 0” (use `$&` for the full match).
+
+For the full algorithm, see [ECMA-262 `GetSubstitution`][].
+
+[ECMA-262 `GetSubstitution`]: https://tc39.es/ecma262/#sec-getsubstitution
+[String.replace()]:
+  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
+
 ### Limitations
 
-- XML processing instructions cannot contain unescaped `>` characters. Use
-  `&gt;` if a `>` is needed in a pattern value.
+- XML processing instructions cannot contain `>` (including inside quoted
+  attribute values). For a regexp that must match `>`, use an escape such as
+  `\x3E` instead of a literal `>`.
 
 ## Processing Order of Arguments
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -11,7 +11,6 @@
 const escapedSlashRe = /\\\//g;
 const zeroChar = '\u0000';
 const endRe = /^g;?\s*$/;
-const matchDollarNumRe = /(\$+)(&|\d*)/g;
 const slashLetterRe = /\\([\\nt])/g;
 const slashHexRe = /\\x(..)/g;
 
@@ -179,6 +178,11 @@ export function encodeSlashChar(s: string): string {
     .replaceAll(zeroChar, '\\');
 }
 
+/**
+ * Applies one `/pattern/replacement/g` segment. Replacement string semantics match
+ * {@link String.prototype.replace} / ECMA-262 `GetSubstitution` (Dart port had
+ * custom logic because Dart differs).
+ */
 function applyReplaceOne(
   code: string,
   reSource: string,
@@ -186,37 +190,7 @@ function applyReplaceOne(
 ): string {
   const replacement = encodeSlashChar(replacementRaw);
   const re = new RegExp(reSource, 'g');
-
-  if (!matchDollarNumRe.test(replacement)) {
-    matchDollarNumRe.lastIndex = 0;
-    return code.replaceAll(re, replacement);
-  }
-  matchDollarNumRe.lastIndex = 0;
-
-  return code.replaceAll(re, (match, ...args: unknown[]) => {
-    const captureArgs = args.slice(0, -2) as string[];
-    const groupCount = captureArgs.length;
-
-    matchDollarNumRe.lastIndex = 0;
-    return replacement.replaceAll(
-      matchDollarNumRe,
-      (_m0, dollars: string, ref: string) => {
-        const numDollarChar = dollars.length;
-        const dollarOut = '$'.repeat(numDollarChar >> 1);
-
-        if (numDollarChar % 2 === 0 || ref === '') {
-          return `${dollarOut}${ref}`;
-        }
-        if (ref === '&') return `${dollarOut}${match}`;
-
-        const argNum = Number.parseInt(ref, 10);
-        const resolved = Number.isNaN(argNum) ? groupCount + 1 : argNum;
-        if (resolved > groupCount) return `${dollarOut}$${ref}`;
-        const g = captureArgs[resolved - 1];
-        return `${dollarOut}${g ?? ''}`;
-      },
-    );
-  });
+  return code.replaceAll(re, replacement);
 }
 
 /**

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,85 @@
+# Tests
+
+Vitest drives unit, integration, and golden tests. Run `npm test` (see
+[`package.json`](../package.json) → `scripts`).
+
+## Fragment PI argument coverage
+
+Fragment processing-instruction arguments are defined in
+[`docs/spec.md`](../docs/spec.md) (Recognized Arguments table). Coverage is
+**split by design**:
+
+Role of each test file:
+
+- **`inject.test.ts`** — Direct `injectMarkdown` calls: PIs, fences, errors,
+  set/fragment stats, many edge paths.
+- **`transform.test.ts`** — `applyExcerptTransforms` / `parseIndentBy`:
+  transform pipeline in isolation.
+- **`updater-goldens.test.ts`** — Full `injectMarkdown` + `readFile` over
+  vendored [`code_excerpt_updater`][] `test_data` fixtures (Dart golden parity).
+
+Together, every fragment argument below is exercised somewhere.
+
+### Fragment argument coverage
+
+| Argument                     | `inject`[^1] | Tr[^2] | Goldens (examples)                                                       |
+| ---------------------------- | ------------ | ------ | ------------------------------------------------------------------------ |
+| Positional path              | Yes          | —      | Many fixtures                                                            |
+| `region`                     | Yes          | —      | E.g. `basic_with_region.dart`, `basic_with_empty_region.md`              |
+| `skip`                       | Yes          | Yes    | `no_change/skip-and-take.md`                                             |
+| `take`                       | —            | Yes    | `no_change/skip-and-take.md`                                             |
+| `from`                       | —            | Yes    | `no_change/basic_with_args.md`                                           |
+| `to`                         | —            | Yes    | `no_change/basic_with_args.md`                                           |
+| `remove`                     | —            | Yes    | `remove.md`, `no_change/diff.md`                                         |
+| `retain`                     | —            | Yes    | `retain.md`, `arg-order.md`                                              |
+| `replace` (on fragment line) | Partial[^3]  | Yes    | `arg-order.md` (`replace` + `retain` on same PI)                         |
+| `indent-by`                  | —            | Yes    | `no_comment_prefix.md`, `basic_no_region.dart`, `basic_with_region.dart` |
+| `plaster`                    | Yes[^4]      | —      | `excerpt_yaml/plaster.md`, `plaster-global-option.md`                    |
+
+[^1]: `inject.test.ts`
+
+[^2]: `transform.test.ts`
+
+[^3]: Set-level `replace` only
+
+[^4]: `excerptsYaml`
+
+`inject.test.ts` does not re-test every transform keyword; goldens and
+`transform.test.ts` cover those paths end-to-end or in isolation.
+
+### `replace` pipeline coverage
+
+Same [`replace` syntax](../docs/spec.md#replace-expressions) as in the spec
+(`/regexp/replacement/g`, optional `;`-separated steps). Most **fragment**
+`replace=` examples live in **goldens**; `inject.test.ts` mainly uses **set**
+`replace` (file-level) plus one **set** pipeline with two steps.
+
+Scenario coverage:
+
+- **One `/re/repl/g` step**
+  - `inject.test.ts`: yes (set `replace` on PI; not fragment-only)
+  - `transform.test.ts`: yes
+  - Goldens: yes (`replace.md`, `arg-order.md`, …)
+- **Multiple `;`-separated steps**
+  - `inject.test.ts`: yes (set `replace="/a/x/g;/b/y/g"`)
+  - `transform.test.ts`: yes (`parseReplacePipeline`)
+  - Goldens: yes (`replace.md`)
+- **ECMA `GetSubstitution` in replacement (`$1`, `$0`, `$10`, …)**
+  - `inject.test.ts`: —
+  - `transform.test.ts`: yes (`replace with capture groups`, `$0`, `$10`)
+  - Goldens: yes (`replace.md`, e.g. `$1`, `$&`)
+- **Whole match in replacement (`$&`)**
+  - `inject.test.ts`: —
+  - `transform.test.ts`: —
+  - Goldens: yes (`replace.md`)
+
+### Related behavior (outside the fragment table)
+
+| Topic                                   | Where                                  |
+| --------------------------------------- | -------------------------------------- |
+| Set `path-base` / `replace` / `plaster` | `inject.test.ts`, goldens              |
+| `globalReplace` (CLI-style)             | `inject.test.ts`, golden `replace.md`  |
+| Unsupported `diff-with`                 | `inject.test.ts` (error path)          |
+| Liquid `{% prettify %}` fences          | `inject.test.ts`, golden `prettify.md` |
+
+[`code_excerpt_updater`]: https://github.com/chalin/code_excerpt_updater

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -169,6 +169,34 @@ describe('transform', () => {
       expect(out).toEqual(['L42']);
     });
 
+    // ECMA-262 `GetSubstitution`: `$0`, `$00`, ... are interpreted literally as
+    // `$0`, `$00`, ... (no substitution), for details see {@link
+    // https://tc39.es/ecma262/#sec-getsubstitution}.
+    it('replace $0 matches JS behavior (literal $0, not full match)', () => {
+      for (const dz of ['$0', '$00', '$000']) {
+        // Sanity check expected JS behavior.
+        expect('ab'.replace(/a/, dz)).toBe(`${dz}b`);
+
+        const out = applyExcerptTransforms(['ab'], {
+          replace: `/a/${dz}/g`,
+        });
+        expect(out).toEqual([`${dz}b`]);
+      }
+    });
+
+    // ECMA-262 `GetSubstitution`: `$` + digits uses the longest *valid* capture
+    // reference (≤99), not a greedy parse of all digits — e.g. with one group,
+    // `$10` is `$1` + literal `0`, not group 10 (nor literal `$10`).
+    it('replace $10 matches JS when only one capture group (not greedy digits)', () => {
+      const js = 'ab'.replace(/(a)/, '$10');
+      expect(js).toBe('a0b');
+
+      const out = applyExcerptTransforms(['ab'], {
+        replace: String.raw`/(a)/$10/g`,
+      });
+      expect(out).toEqual(['a0b']);
+    });
+
     it('indent-by out of range', () => {
       const onError = vi.fn();
       const out = applyExcerptTransforms(['a'], { indentBy: '101' }, onError);


### PR DESCRIPTION
- Replaces custom `replace` substitution handling with native JavaScript replacement semantics in `transform.ts`.
- Documents `replace` expression syntax and replacement semantics in `docs/spec.md`.
- Adds transform tests for capture-substitution edge cases such as `$0` and `$10`.
- Adds `test/README.md` to summarize argument and `replace`-pipeline coverage across unit and golden tests.