### PR TITLE
Recover fragment PI arg-order semantics and add direct arg-processing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ overview, installation, and clone workflow.
 - [docs/architecture.md](docs/architecture.md) — Module map, data flow, Dart
   repository lineage, Dart→TypeScript porting notes
 - [docs/spec.md](docs/spec.md) — `<?code-excerpt?>` instruction syntax and
-  transform order
+  transform argument order (PI attribute order in inject)
 - [docs/plan.md](docs/plan.md) — Phased porting plan with progress checkboxes
 - [docs/scope.md](docs/scope.md) — Feature scoping for v1
 - [docs/tooling.md](docs/tooling.md) — Tooling stack, rationale, and how scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][], and this project adheres to
   fences and paired by fence **kind** (backtick vs tilde vs Liquid prettify),
   consistent with backtick and prettify blocks.
 - CLI **`--version`**, reporting `version` from `package.json`.
+- Focused PI arg-processing tests for direct parser/classifier coverage.
 
 ### Changed
 
@@ -27,6 +28,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 - Spec now states clearly that excerpt **transform operations** run in the order
   they appear in the fragment instruction.
   [Details](docs/spec.md#processing-order-of-transform-arguments).
+- Fragment PI arg processing now preserves repeated transform operations in
+  appearance order instead of coalescing them by key.
 
 ## [v0.1.0][] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog][], and this project adheres to
 - README: improved installation instructions and Overview wording.
 - [`replace` expressions](docs/spec.md#replace-expressions) now features full
   JavaScript semantics
+- Spec now states clearly that excerpt **transform operations** run in the order
+  they appear in the fragment instruction.
+  [Details](docs/spec.md#processing-order-of-transform-arguments).
 
 ## [v0.1.0][] - 2026-04-13
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,7 +96,7 @@ orchestrates the extraction + transform pipeline for each code block.
   inject context compose on the joined excerpt string after per-instruction
   transforms (Dart `Updater` `fileAndCmdLineCodeTransformer` order).
 - Per-instruction transform order follows named-argument order in the PI; see
-  [`docs/spec.md`](spec.md#processing-order-of-arguments).
+  [`docs/spec.md`](spec.md#processing-order-of-transform-arguments).
 - `readFile(path, region?)` mirrors Dart `ExcerptGetter` when the callback
   resolves `.txt` fragments and `.excerpt.yaml` regions; optional
   `escapeNgInterpolation` / `globalPlasterTemplate` match updater defaults.

--- a/docs/migration-notes.md
+++ b/docs/migration-notes.md
@@ -1,0 +1,19 @@
+# Migration Notes
+
+This document tracks the migration of the Dart excerpter tooling to TypeScript.
+
+## Plaster processing
+
+
+About the original model:
+
+- From plaster.dart, I see that the `plaster` args were setting `plasterTemplate`; and that `plaster=""` meant "use the lang template default".
+- There was never any capacity for a user to set only, what we've started calling, the "plaster string", only the full "plaster template".
+
+If memory serves, in the very first implementation, plaster was "···". That was it: no template, no lang specific comment, just "···". With experience, I realized that it was a bad idea to have a bare "···" plaster, because it rendered the code excerpts invalid from the pov of tooling. So I introduced the idea of lang specific comments to contain the plaster in.
+
+In a bit more detail:
+
+- There was a plaster, default as "···", configurable
+- And the `--yaml` flag, which would cause the plaster to be embedded in a lang specific comment, unless overridden
+- All plaster argument values affected the plaster _template_

--- a/docs/migration-notes.md
+++ b/docs/migration-notes.md
@@ -4,16 +4,23 @@ This document tracks the migration of the Dart excerpter tooling to TypeScript.
 
 ## Plaster processing
 
-
 About the original model:
 
-- From plaster.dart, I see that the `plaster` args were setting `plasterTemplate`; and that `plaster=""` meant "use the lang template default".
-- There was never any capacity for a user to set only, what we've started calling, the "plaster string", only the full "plaster template".
+- From plaster.dart, I see that the `plaster` args were setting
+  `plasterTemplate`; and that `plaster=""` meant "use the lang template
+  default".
+- There was never any capacity for a user to set only, what we've started
+  calling, the "plaster string", only the full "plaster template".
 
-If memory serves, in the very first implementation, plaster was "···". That was it: no template, no lang specific comment, just "···". With experience, I realized that it was a bad idea to have a bare "···" plaster, because it rendered the code excerpts invalid from the pov of tooling. So I introduced the idea of lang specific comments to contain the plaster in.
+If memory serves, in the very first implementation, plaster was "···". That was
+it: no template, no lang specific comment, just "···". With experience, I
+realized that it was a bad idea to have a bare "···" plaster, because it
+rendered the code excerpts invalid from the pov of tooling. So I introduced the
+idea of lang specific comments to contain the plaster in.
 
 In a bit more detail:
 
 - There was a plaster, default as "···", configurable
-- And the `--yaml` flag, which would cause the plaster to be embedded in a lang specific comment, unless overridden
+- And the `--yaml` flag, which would cause the plaster to be embedded in a lang
+  specific comment, unless overridden
 - All plaster argument values affected the plaster _template_

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -138,6 +138,19 @@ versions, such as:
 - [ ] (IN PROGRESS) [open-telemetry/opentelemetry.io][]
 - [ ] [dart-lang/site-www][]
 
+## Appendix - possible later `inject.ts` refactoring
+
+If the current `inject.ts` shape becomes a maintenance problem, consider a later
+split along responsibility boundaries:
+
+- target-file PI/block scanning and rewrite orchestration
+- PI arg parsing and classification
+- source excerpt resolution (`readFile` + region selection)
+- fragment rendering (plaster, TOps, scoped replaces, final formatting)
+
+Keep this separate from the current arg-order transition unless it materially
+reduces risk.
+
 [open-telemetry/opentelemetry.io]:
   https://github.com/open-telemetry/opentelemetry.io
 [dart-lang/site-www]: https://github.com/dart-lang/site-www

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -31,9 +31,9 @@ This document defines the feature scope for `code-excerpter` v1.
 
 ### Code transforms and settings
 
-Transform operations, setting arguments, and scope-sensitive `replace`
-semantics are in scope. See [`docs/spec.md`](spec.md#pi-arguments) for the
-canonical Scope/Kind table and fragment-order rules.
+Transform operations, setting arguments, and scope-sensitive `replace` semantics
+are in scope. See [`docs/spec.md`](spec.md#pi-arguments) for the canonical
+Scope/Kind table and fragment-order rules.
 
 ### Path-base set instructions
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -29,10 +29,11 @@ This document defines the feature scope for `code-excerpter` v1.
 - Overlapping and nested regions.
 - Plaster handling (language-specific filler comment at region join points).
 
-### Code transforms
+### Code transforms and settings
 
-`skip`, `take`, `from`, `to`, `remove`, `retain`, `replace`, `indent-by`. See
-[`docs/spec.md`](spec.md#processing-order-of-arguments) for ordering rules.
+Transform operations, setting arguments, and scope-sensitive `replace`
+semantics are in scope. See [`docs/spec.md`](spec.md#pi-arguments) for the
+canonical Scope/Kind table and fragment-order rules.
 
 ### Path-base set instructions
 

--- a/docs/spec-fixes.md
+++ b/docs/spec-fixes.md
@@ -1,0 +1,15 @@
+# Spec parity backlog
+
+Optional checklist of **remaining** gaps between
+[`chalin/code_excerpt_updater`](https://github.com/chalin/code_excerpt_updater)
+README behavior/notes and [`docs/spec.md`](spec.md). Transform **argument
+order** is documented in
+[§ Processing order of transform arguments](spec.md#processing-order-of-transform-arguments).
+
+- [ ] Document negative `skip` / `take` in the Recognized Arguments table (see
+      README and `applySkip` / `applyTake` in `src/transform.ts`).
+- [ ] Document region-name normalization (non-word runs → `-`) for `(region)`
+      and `region=`.
+- [ ] Document leading-`/` string escape (`\/…`) for `remove` / `retain` /
+      `from` / `to` string patterns.
+- [ ] Document `$defaultPlaster` in the plaster section.

--- a/docs/spec-fixes.md
+++ b/docs/spec-fixes.md
@@ -2,9 +2,9 @@
 
 Optional checklist of **remaining** gaps between
 [`chalin/code_excerpt_updater`](https://github.com/chalin/code_excerpt_updater)
-README behavior/notes and [`docs/spec.md`](spec.md). Transform **argument
-order** is documented in
-[§ Processing order of transform arguments](spec.md#processing-order-of-transform-arguments).
+README behavior/notes and [`docs/spec.md`](spec.md). Transform ordering and
+fragment-setting semantics are documented in
+[§ Transform operations and fragment settings](spec.md#transform-operations-and-fragment-settings).
 
 - [ ] Document negative `skip` / `take` in the Recognized Arguments table (see
       README and `applySkip` / `applyTake` in `src/transform.ts`).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -154,22 +154,27 @@ For the full algorithm, see [ECMA-262 `GetSubstitution`][].
   attribute values). For a regexp that must match `>`, use an escape such as
   `\x3E` instead of a literal `>`.
 
-## Processing Order of Arguments
+## Processing order of transform arguments
 
-When multiple transform arguments are present, `code-excerpter` applies them in
-**the order they appear** in the processing instruction.
+These fragment instruction keys are **line transform operations**:
 
-The usual relative order is:
+- `from`
+- `indent-by`
+- `remove`
+- `replace`
+- `retain`
+- `skip`
+- `take`
+- `to`
 
-1. `skip`
-2. `take`
-3. `from`
-4. `to`
-5. `remove`
-6. `retain`
-7. `replace`
+When more than one of these keys appear in a fragment instruction, they are
+applied in the order they appear in the fragment instruction, except for the following:
 
-`indent-by` is handled separately after the transform chain.
+- `plaster` is applied to joined region spans first
+- `indent-by` is applied last
+
+If the same transform key appears more than once, order stays where the key was
+first seen; the **last** attribute value wins for that key.
 
 ## Instruction and fence prefixes
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -302,8 +302,8 @@ first.
 ## Plaster Handling
 
 When a region is composed of non-contiguous segments (e.g., a region opened and
-closed multiple times), a _plaster template_ is inserted between the segments
-to indicate that content has been omitted.
+closed multiple times), a _plaster template_ is inserted between the segments to
+indicate that content has been omitted.
 
 The default plaster string is three dots: `···`.
 
@@ -319,15 +319,14 @@ language-specific comment, for example:
 
 Those language-shaped default plaster templates apply when excerpt injection
 runs in **YAML excerpt mode** (`MarkdownInjectContext.excerptsYaml`); otherwise
-the extractor still inserts the raw plaster string `···` between segments and
-it is passed through
-unchanged (unless overridden or removed via `plaster`).
+the extractor still inserts the raw plaster string `···` between segments and it
+is passed through unchanged (unless overridden or removed via `plaster`).
 
 The `plaster` argument sets the full plaster template, not just the plaster
-string. For example, `plaster="/* $defaultPlaster */"` uses that whole
-template, while `plaster="none"` removes plaster injection. On a set
-instruction, `plaster="unset"` clears the file-level plaster template and falls
-back to the global/default behavior.
+string. For example, `plaster="/* $defaultPlaster */"` uses that whole template,
+while `plaster="none"` removes plaster injection. On a set instruction,
+`plaster="unset"` clears the file-level plaster template and falls back to the
+global/default behavior.
 
 ## Acknowledgments
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -86,39 +86,83 @@ line must contain **at most one** named argument (or one bare flag such as
 `plaster` with no `=`). Set values apply to all subsequent fragment instructions
 in the same file until another set instruction for that key replaces them.
 
-## Recognized Arguments
+## PI Arguments
 
 Fragment instructions may use the following named arguments (plus the positional
 path string). Set instructions accept **only** `path-base`, `replace`,
 `plaster`, or no-op compatibility keys `class` / `title`—see
 [Set instruction](#set-instruction); any other set key triggers a warning.
 
-| Argument name   | Argument values              | Description                                                           |
-| --------------- | ---------------------------- | --------------------------------------------------------------------- |
-| _(path string)_ | _string_                     | Positional: `"path/file.ext (region)"`                                |
-| `path-base`     | _string_                     | Sets the base directory for source file paths (set instruction)       |
-| `region`        | _string_                     | Named region to extract (alternative to inline `(region)`)            |
-| `from`          | _string_ \| `/regex/`        | Start extraction from the first line matching this pattern            |
-| `to`            | _string_ \| `/regex/`        | End after the first line matching this pattern (that line kept)       |
-| `skip`          | _integer_                    | Skip the first N lines of the extracted region                        |
-| `take`          | _integer_                    | Take only the first N lines of the extracted region                   |
-| `remove`        | _string_ \| `/regex/`        | Remove all lines matching this pattern                                |
-| `retain`        | _string_ \| `/regex/`        | Keep only lines matching this pattern                                 |
-| `replace`       | `/pattern/replacement/g;`... | Regex replace within extracted lines (supports multiple replacements) |
-| `indent-by`     | _integer_                    | Prepend N spaces to every output line                                 |
-| `plaster`       | _string_                     | Override the plaster comment (use `"none"` to disable)                |
+| Argument        | Scope | Kind  | Argument values              | Description                                                     |
+| --------------- | ----- | ----- | ---------------------------- | --------------------------------------------------------------- |
+| _(path string)_ | F     | -     | _string_                     | Positional: `"path/file.ext (region)"`                          |
+| `path-base`     | S     | S     | _string_                     | Sets the base directory for source file paths                   |
+| `region`        | F     | S     | _string_                     | Named region to extract (alternative to inline `(region)`)      |
+| `from`          | F     | TOp   | _string_ \| `/regex/`        | Start extraction from the first line matching this pattern      |
+| `to`            | F     | TOp   | _string_ \| `/regex/`        | End after the first line matching this pattern (that line kept) |
+| `skip`          | F     | TOp   | _integer_                    | Skip the first N lines of the extracted region                  |
+| `take`          | F     | TOp   | _integer_                    | Take only the first N lines of the extracted region             |
+| `remove`        | F     | TOp   | _string_ \| `/regex/`        | Remove all lines matching this pattern                          |
+| `retain`        | F     | TOp   | _string_ \| `/regex/`        | Keep only lines matching this pattern                           |
+| `replace`       | GSF   | S/TOp | `/pattern/replacement/g;`... | Regex replacement expressions (details below)                   |
+| `indent-by`     | GSF   | S     | _integer_                    | Indent every fragment line by the given number of spaces        |
+| `plaster`       | GSF   | S     | _string_                     | Sets the plaster (details below)                                |
 
-On a fragment instruction, `replace` and `plaster` participate in the transform
-or plaster pass for that excerpt only. As the **sole** argument on a
-[set instruction](#set-instruction), they set file-level defaults (`replace`
-runs on the joined excerpt after fragment transforms; `plaster` sets the
-template for later fragments, and bare `plaster` clears the file default).
+Legend:
+
+- Scope is either:
+  - Global (G), currently via CLI options
+  - File-scoped set instruction (S) or fragment instruction (F)
+- Kind indicates the kind of argument:
+  - Transform operation (TOp) of a fragment instruction
+  - Setting (S) of a fragment or set instruction: can appear at most once.
+    Repeated arguments are reported as errors.
+
+> TODO: `indent-by` global and file-level settings support is not implemented
+> yet.
+
+### Global settings
+
+Global CLI settings are scoped to all files:
+
+- `indent-by` sets a global indent by value.
+- `path-base` sets a global base directory for source file paths.
+- `plaster` sets a global plaster template.
+- `replace` sets a global replacement expression.
+
+### Set instructions
+
+Set instruction settings have file-level scope, and apply to all subsequent
+fragment instructions in the same file. Precedence:
+
+- `indent-by`: overrides global settings
+- `path-base`: appends to the global base directory
+- `plaster`: overrides global settings
+- `replace`: see [Replace order](#replace-order)
+
+### Fragment instructions
+
+Within a fragment instruction:
+
+- TOps are applied strictly in the order they appear in the fragment PI.
+- There can be more than one instance of a TOp; every occurrence is preserved
+  and applied.
+
+Fragment-setting semantics:
+
+- `plaster` determines the plaster comment for the fragment. Applied before
+  transformations.
+- `indent-by` is applied after the excerpt content has been fully transformed.
+  Overrides file-level and global settings.
+- Repeating `indent-by` or `plaster` on the same fragment instruction is an
+  error; the existing fragment block is left unchanged.
+- An invalid setting value is also an error; the existing fragment block is left
+  unchanged.
 
 ### Replace expressions
 
-The `replace` can be followed by a list of one or more semicolon-separated (`;`)
-Perl-like substitution expressions, but with JavaScript semantics. Each
-expression is of the form:
+The `replace` can be followed by a list of one or more semicolon-separated
+substitution expressions. Each expression is of the form:
 
 ```text
 /pattern/replacement/g
@@ -144,6 +188,13 @@ string replacer.
 
 For the full algorithm, see [ECMA-262 `GetSubstitution`][].
 
+### Replace order
+
+- Fragment-scoped `replace` expressions are applied first, in the order they
+  appear in the fragment PI.
+- The last set-instruction `replace` expression is applied next.
+- Finally the global `replace` expression is applied.
+
 [ECMA-262 `GetSubstitution`]: https://tc39.es/ecma262/#sec-getsubstitution
 [String.replace()]:
   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
@@ -153,28 +204,6 @@ For the full algorithm, see [ECMA-262 `GetSubstitution`][].
 - XML processing instructions cannot contain `>` (including inside quoted
   attribute values). For a regexp that must match `>`, use an escape such as
   `\x3E` instead of a literal `>`.
-
-## Processing order of transform arguments
-
-These fragment instruction keys are **line transform operations**:
-
-- `from`
-- `indent-by`
-- `remove`
-- `replace`
-- `retain`
-- `skip`
-- `take`
-- `to`
-
-When more than one of these keys appear in a fragment instruction, they are
-applied in the order they appear in the fragment instruction, except for the following:
-
-- `plaster` is applied to joined region spans first
-- `indent-by` is applied last
-
-If the same transform key appears more than once, order stays where the key was
-first seen; the **last** attribute value wins for that key.
 
 ## Instruction and fence prefixes
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -82,9 +82,9 @@ file-level `replace`, and file-level `plaster`:
 ```
 
 A set instruction has no path argument and no following code block. Each set
-line must contain **at most one** named argument (or one bare flag such as
-`plaster` with no `=`). Set values apply to all subsequent fragment instructions
-in the same file until another set instruction for that key replaces them.
+line must contain **at most one** named argument. Set values apply to all
+subsequent fragment instructions in the same file until another set instruction
+for that key replaces them.
 
 ## PI Arguments
 
@@ -127,7 +127,7 @@ Global CLI settings are scoped to all files:
 
 - `indent-by` sets a global indent by value.
 - `path-base` sets a global base directory for source file paths.
-- `plaster` sets a global plaster template.
+- `plaster` sets the global plaster template.
 - `replace` sets a global replacement expression.
 
 ### Set instructions
@@ -137,7 +137,9 @@ fragment instructions in the same file. Precedence:
 
 - `indent-by`: overrides global settings
 - `path-base`: appends to the global base directory
-- `plaster`: overrides global settings
+- `plaster`: overrides global settings; `plaster="unset"` clears the file-level
+  plaster template; bare `plaster` is invalid and should be written as
+  `plaster="unset"`
 - `replace`: see [Replace order](#replace-order)
 
 ### Fragment instructions
@@ -150,8 +152,13 @@ Within a fragment instruction:
 
 Fragment-setting semantics:
 
-- `plaster` determines the plaster comment for the fragment. Applied before
+- `plaster` determines the plaster template for the fragment. Applied before
   transformations.
+- `plaster="<template>"` sets the full plaster template for the fragment,
+  including any language-specific comment wrapper.
+- `plaster="none"` ensures that no plaster template is injected into the
+  excerpt.
+- `plaster="unset"` and bare `plaster` are invalid in fragment scope.
 - `indent-by` is applied after the excerpt content has been fully transformed.
   Overrides file-level and global settings.
 - Repeating `indent-by` or `plaster` on the same fragment instruction is an
@@ -295,11 +302,13 @@ first.
 ## Plaster Handling
 
 When a region is composed of non-contiguous segments (e.g., a region opened and
-closed multiple times), a _plaster_ comment is inserted between the segments to
-indicate that content has been omitted.
+closed multiple times), a _plaster template_ is inserted between the segments
+to indicate that content has been omitted.
 
-The default plaster consists of three dots (`···`) inside a language-specific
-comment, for example:
+The default plaster string is three dots: `···`.
+
+The default plaster template is the default plaster string inside a
+language-specific comment, for example:
 
 | Language     | Plaster comment |
 | ------------ | --------------- |
@@ -308,13 +317,17 @@ comment, for example:
 | CSS, SCSS    | `/* ··· */`     |
 | YAML         | `# ···`         |
 
-Those language-shaped defaults apply when excerpt injection runs in **YAML
-excerpt mode** (`MarkdownInjectContext.excerptsYaml`); otherwise the extractor
-still inserts the raw `···` marker between segments and it is passed through
+Those language-shaped default plaster templates apply when excerpt injection
+runs in **YAML excerpt mode** (`MarkdownInjectContext.excerptsYaml`); otherwise
+the extractor still inserts the raw plaster string `···` between segments and
+it is passed through
 unchanged (unless overridden or removed via `plaster`).
 
-The plaster can be overridden per-instruction with the `plaster` argument, or
-disabled entirely with `plaster="none"`.
+The `plaster` argument sets the full plaster template, not just the plaster
+string. For example, `plaster="/* $defaultPlaster */"` uses that whole
+template, while `plaster="none"` removes plaster injection. On a set
+instruction, `plaster="unset"` clears the file-level plaster template and falls
+back to the global/default behavior.
 
 ## Acknowledgments
 

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -6,8 +6,8 @@ import {
 } from './extract.js';
 import type { InstructionStats } from './instructionStats.js';
 import {
-  applyExcerptTransformsInOrder,
-  parseIndentBy,
+  applyOrderedExcerptTransformOps,
+  type ExcerptTransformOp,
   parseReplacePipeline,
 } from './transform.js';
 
@@ -41,12 +41,14 @@ const SET_KNOWN_KEYS = new Set([
   'title',
 ]);
 
+interface ParsedNamedArgEntry {
+  key: string;
+  value: string | undefined;
+  hasValue: boolean;
+}
+
 interface ParsedNamedArgs {
-  map: Map<string, string>;
-  /** Keys present as bare flags (`plaster` with no `=`). */
-  flags: Set<string>;
-  /** First-occurrence order of every named key (insertion order in the PI). */
-  keyOrder: string[];
+  entries: ParsedNamedArgEntry[];
 }
 
 // TODO: bring in x`` string template / regex helper
@@ -86,8 +88,8 @@ export interface MarkdownInjectContext {
   /** Initial `path-base` (directory prefix for excerpt sources). */
   pathBase?: string;
   /**
-   * When `true`, applies language-specific plaster templates in YAML excerpt
-   * mode (default `false`, legacy fragment-style behavior).
+   * When `true`, applies language-specific plaster comment wrappers in YAML
+   * excerpt mode (default `false`, legacy fragment-style behavior).
    */
   excerptsYaml?: boolean;
   /** Default extra spaces when `indent-by` is omitted on a fragment directive. */
@@ -98,7 +100,7 @@ export interface MarkdownInjectContext {
    */
   globalReplace?: string;
   /**
-   * Default plaster template when neither the PI nor a file-level `plaster` set
+   * Default plaster text when neither the PI nor a file-level `plaster` set
    * instruction overrides it.
    */
   globalPlasterTemplate?: string;
@@ -152,9 +154,7 @@ function parseNamedArgs(
   named: string,
   onError?: (msg: string) => void,
 ): ParsedNamedArgs {
-  const map = new Map<string, string>();
-  const flags = new Set<string>();
-  const keyOrder: string[] = [];
+  const entries: ParsedNamedArgEntry[] = [];
   let rest = named.trim();
   while (rest.length > 0) {
     const m = NAMED_ARG_RE.exec(rest);
@@ -164,15 +164,99 @@ function parseNamedArgs(
     }
     const key = m[1]!;
     const eqOrBare = m[2] ?? '';
-    if (!keyOrder.includes(key)) keyOrder.push(key);
-    if (eqOrBare.trimStart().startsWith('=')) {
-      map.set(key, m[3] ?? '');
-    } else {
-      flags.add(key);
-    }
+    entries.push({
+      key,
+      value: m[3] ?? undefined,
+      hasValue: eqOrBare.trimStart().startsWith('='),
+    });
     rest = rest.slice(m[0].length);
   }
-  return { map, flags, keyOrder };
+  return { entries };
+}
+
+type FragmentSettingName = 'region' | 'indent-by' | 'plaster';
+
+interface ParsedFragmentArgs {
+  transformOps: ExcerptTransformOp[];
+  regionValue: string | undefined;
+  indentByRaw: string | undefined;
+  plasterTemplate: string | undefined;
+  hasBarePlaster: boolean;
+  hasUnsupportedDiff: boolean;
+}
+
+function parseFragmentArgs(
+  parsed: ParsedNamedArgs,
+  onError?: (msg: string) => void,
+): ParsedFragmentArgs | null {
+  const transformOps: ExcerptTransformOp[] = [];
+  let regionValue: string | undefined;
+  let indentByRaw: string | undefined;
+  let plasterTemplate: string | undefined;
+  let hasBarePlaster = false;
+  let hasUnsupportedDiff = false;
+  const seenSettings = new Set<FragmentSettingName>();
+
+  const rejectRepeatedSetting = (key: FragmentSettingName): null => {
+    onError?.(`${key}: repeated setting argument on fragment instruction`);
+    return null;
+  };
+
+  for (const entry of parsed.entries) {
+    switch (entry.key) {
+      case 'from':
+      case 'to':
+      case 'skip':
+      case 'take':
+      case 'remove':
+      case 'retain':
+      case 'replace':
+        if (!entry.hasValue) continue;
+        transformOps.push({
+          name: entry.key,
+          value: entry.value ?? '',
+        });
+        break;
+      case 'region':
+        if (seenSettings.has('region')) return rejectRepeatedSetting('region');
+        seenSettings.add('region');
+        regionValue = entry.hasValue ? (entry.value ?? '') : undefined;
+        break;
+      case 'indent-by':
+        if (seenSettings.has('indent-by')) {
+          return rejectRepeatedSetting('indent-by');
+        }
+        seenSettings.add('indent-by');
+        indentByRaw = entry.hasValue ? (entry.value ?? '') : undefined;
+        break;
+      case 'plaster':
+        if (seenSettings.has('plaster')) {
+          return rejectRepeatedSetting('plaster');
+        }
+        seenSettings.add('plaster');
+        if (entry.hasValue) {
+          plasterTemplate = entry.value ?? '';
+        } else {
+          hasBarePlaster = true;
+        }
+        break;
+      case 'diff-with':
+      case 'diff-u':
+        hasUnsupportedDiff = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {
+    transformOps,
+    regionValue,
+    indentByRaw,
+    plasterTemplate,
+    hasBarePlaster,
+    hasUnsupportedDiff,
+  };
 }
 
 function normalizeRegionName(region: string): string {
@@ -243,55 +327,68 @@ const PLASTER_COMMENT_DELIMS_BY_LANG = new Map<string, PlasterCommentDelims>([
 ]);
 
 function formatPlasterWithDelims(
-  marker: string,
+  text: string,
   d: PlasterCommentDelims,
 ): string {
-  return [d.start, marker, ...(d.end ? [d.end] : [])].join(' ');
+  if (text === '') {
+    return d.end ? `${d.start} ${d.end}` : d.start;
+  }
+  return d.end ? `${d.start} ${text} ${d.end}` : `${d.start} ${text}`;
 }
 
-function plasterTemplateForLang(lang: string): string | null {
+function plasterTextForLang(text: string, lang: string): string | null {
   const d = PLASTER_COMMENT_DELIMS_BY_LANG.get(lang.toLowerCase());
   if (d === undefined) return null;
-  return formatPlasterWithDelims(DEFAULT_PLASTER, d);
+  return formatPlasterWithDelims(text, d);
 }
 
 /**
- * Plaster pass: `plaster="none"` removes default-plaster lines; if `excerptsYaml`
- * is false, returns lines unchanged; otherwise substitutes language templates
- * around `DEFAULT_PLASTER`.
+ * Plaster pass: `plaster="none"` removes default-plaster lines. In legacy mode,
+ * explicit plaster text replaces the raw `DEFAULT_PLASTER` marker. In YAML
+ * excerpt mode, plaster text is wrapped using the language-specific plaster
+ * comment form.
  */
 function applyPlasterToLines(
   lines: string[],
-  plasterTemplate: string | undefined,
+  plasterText: string | undefined,
   lang: string,
   excerptsYaml: boolean,
 ): string[] {
-  if (plasterTemplate === 'none') {
+  if (plasterText === 'none') {
     return lines.filter((line) => !line.includes(DEFAULT_PLASTER));
   }
   if (!excerptsYaml) {
-    return lines;
+    if (plasterText === undefined) return lines;
+    return lines
+      .join('\n')
+      .split(DEFAULT_PLASTER)
+      .join(plasterText)
+      .split('\n');
   }
-  let tpl: string | null =
-    plasterTemplate !== undefined && plasterTemplate !== ''
-      ? plasterTemplate.replaceAll('$defaultPlaster', DEFAULT_PLASTER)
-      : null;
-  if (tpl === null || tpl === '') {
-    const def = plasterTemplateForLang(lang);
-    if (def === null) return lines;
-    tpl = def;
-  }
+  const tpl = plasterTextForLang(plasterText ?? DEFAULT_PLASTER, lang);
+  if (tpl === null) return lines;
   const joined = lines.join('\n');
   return joined.split(DEFAULT_PLASTER).join(tpl).split('\n');
 }
 
-function parseIndentForBlock(
+function tryParseFragmentIndent(
   raw: string | undefined,
   defaultIndentation: number,
   onError?: (msg: string) => void,
-): number {
-  if (raw === undefined) return defaultIndentation;
-  return parseIndentBy(raw, onError);
+): { ok: boolean; value: number } {
+  if (raw === undefined) {
+    return { ok: true, value: defaultIndentation };
+  }
+  if (!/^[-+]?\d+$/.test(raw)) {
+    onError?.(`indent-by: error parsing integer value: ${JSON.stringify(raw)}`);
+    return { ok: false, value: defaultIndentation };
+  }
+  const n = Number.parseInt(raw, 10);
+  if (n < 0 || n > 100) {
+    onError?.(`indent-by: integer out of range: ${n}`);
+    return { ok: false, value: defaultIndentation };
+  }
+  return { ok: true, value: n };
 }
 
 /** Consumes a markdown code fence (opening through closing) from `queue`. */
@@ -356,7 +453,7 @@ export function injectMarkdown(
   }
 
   const handleSetInstruction = (pn: ParsedNamedArgs): void => {
-    const nKeys = pn.map.size + pn.flags.size;
+    const nKeys = pn.entries.length;
     if (nKeys > 1) {
       err('set instruction should have at most one argument');
       return;
@@ -364,12 +461,21 @@ export function injectMarkdown(
     if (nKeys === 0) {
       return;
     }
-    if (pn.map.has('path-base')) {
-      pathBase = pn.map.get('path-base') ?? '';
+    const entry = pn.entries[0]!;
+    if (entry.key === 'path-base') {
+      if (!entry.hasValue) {
+        err('path-base: invalid setting value on set instruction');
+        return;
+      }
+      pathBase = entry.hasValue ? (entry.value ?? '') : '';
       return;
     }
-    if (pn.map.has('replace')) {
-      const val = pn.map.get('replace') ?? '';
+    if (entry.key === 'replace') {
+      if (!entry.hasValue) {
+        err('replace: invalid setting value on set instruction');
+        return;
+      }
+      const val = entry.hasValue ? (entry.value ?? '') : '';
       if (val === '') {
         fileReplacePipeline = null;
       } else {
@@ -378,21 +484,24 @@ export function injectMarkdown(
       }
       return;
     }
-    if (pn.map.has('plaster') || pn.flags.has('plaster')) {
-      filePlasterTemplate = pn.flags.has('plaster')
-        ? undefined
-        : pn.map.get('plaster');
+    if (entry.key === 'plaster') {
+      if (!entry.hasValue) {
+        err('plaster: invalid setting value on set instruction');
+        return;
+      }
+      const val = entry.value ?? '';
+      filePlasterTemplate = val === 'unset' ? undefined : val;
       return;
     }
-    if (nKeys === 1 && pn.map.has('class')) {
+    if (entry.key === 'class') {
       return;
     }
-    if (nKeys === 1 && (pn.map.has('title') || pn.flags.has('title'))) {
+    if (entry.key === 'title') {
       return;
     }
-    const unknown = [...pn.map.keys(), ...pn.flags].filter(
-      (k) => !SET_KNOWN_KEYS.has(k),
-    );
+    const unknown = pn.entries
+      .map((e) => e.key)
+      .filter((k) => !SET_KNOWN_KEYS.has(k));
     warn(
       `instruction ignored: unrecognized set instruction argument: ${unknown.join(', ')}`,
     );
@@ -405,11 +514,12 @@ export function injectMarkdown(
     linePrefixRaw: string | undefined,
   ): string[] => {
     const namedArgs = parseNamedArgs(namedStr, err);
+    const fragmentArgs = parseFragmentArgs(namedArgs, err);
     const parsed = parsePathAndRegion(unnamed);
     let region = parsed.region;
     const relPath = parsed.path;
-    if (namedArgs.map.has('region')) {
-      region = normalizeRegionName(namedArgs.map.get('region')!);
+    if (fragmentArgs?.regionValue !== undefined) {
+      region = normalizeRegionName(fragmentArgs.regionValue);
     }
 
     const fb = consumeFenceBlock(queue);
@@ -435,7 +545,11 @@ export function injectMarkdown(
     const closing = mid.pop()!;
     const oldInner = mid;
 
-    if (namedArgs.map.has('diff-with') || namedArgs.map.has('diff-u')) {
+    if (fragmentArgs === null) {
+      return [opening, ...oldInner, closing];
+    }
+
+    if (fragmentArgs.hasUnsupportedDiff) {
       err('diff-with / diff-u are not supported in this port');
       return [opening, ...oldInner, closing];
     }
@@ -462,19 +576,22 @@ export function injectMarkdown(
     const lang = codeLang(opening, relPath);
 
     let plasterInput: string | undefined;
-    if (namedArgs.flags.has('plaster')) {
-      plasterInput = undefined;
-    } else if (namedArgs.map.has('plaster')) {
-      plasterInput = namedArgs.map.get('plaster');
+    if (fragmentArgs.hasBarePlaster) {
+      err('plaster: invalid setting value on fragment instruction');
+      return [opening, ...oldInner, closing];
+    } else if (fragmentArgs.plasterTemplate === 'unset') {
+      err('plaster: invalid setting value on fragment instruction');
+      return [opening, ...oldInner, closing];
+    } else if (fragmentArgs.plasterTemplate !== undefined) {
+      plasterInput = fragmentArgs.plasterTemplate;
     } else {
       plasterInput = filePlasterTemplate ?? ctx.globalPlasterTemplate;
     }
     working = applyPlasterToLines(working, plasterInput, lang, excerptsYaml);
 
-    working = applyExcerptTransformsInOrder(
+    working = applyOrderedExcerptTransformOps(
       working,
-      namedArgs.keyOrder,
-      namedArgs.map,
+      fragmentArgs.transformOps,
       err,
     );
 
@@ -487,11 +604,15 @@ export function injectMarkdown(
     }
     working = dropLeadingBlankLines(dropTrailingBlankLines(joined.split('\n')));
 
-    const indentExtra = parseIndentForBlock(
-      namedArgs.map.get('indent-by'),
+    const parsedIndent = tryParseFragmentIndent(
+      fragmentArgs.indentByRaw,
       defaultIndentation,
       err,
     );
+    if (!parsedIndent.ok) {
+      return [opening, ...oldInner, closing];
+    }
+    const indentExtra = parsedIndent.value;
     const indentStr = ' '.repeat(indentExtra);
 
     let linePrefix = linePrefixRaw ?? '';

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -41,13 +41,13 @@ const SET_KNOWN_KEYS = new Set([
   'title',
 ]);
 
-interface ParsedNamedArgEntry {
+export interface ParsedNamedArgEntry {
   key: string;
   value: string | undefined;
   hasValue: boolean;
 }
 
-interface ParsedNamedArgs {
+export interface ParsedNamedArgs {
   entries: ParsedNamedArgEntry[];
 }
 
@@ -150,7 +150,7 @@ function normalizeListLinePrefix(prefix: string): string {
   return prefix;
 }
 
-function parseNamedArgs(
+export function parseNamedArgs(
   named: string,
   onError?: (msg: string) => void,
 ): ParsedNamedArgs {
@@ -176,7 +176,7 @@ function parseNamedArgs(
 
 type FragmentSettingName = 'region' | 'indent-by' | 'plaster';
 
-interface ParsedFragmentArgs {
+export interface ParsedFragmentArgs {
   transformOps: ExcerptTransformOp[];
   regionValue: string | undefined;
   indentByRaw: string | undefined;
@@ -185,7 +185,7 @@ interface ParsedFragmentArgs {
   hasUnsupportedDiff: boolean;
 }
 
-function parseFragmentArgs(
+export function parseFragmentArgs(
   parsed: ParsedNamedArgs,
   onError?: (msg: string) => void,
 ): ParsedFragmentArgs | null {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -20,6 +20,19 @@ const slashLetterRe = /\\([\\nt])/g;
 const slashHexRe = /\\x(..)/g;
 
 export type LinePredicate = (line: string) => boolean;
+export type ExcerptTransformOpName =
+  | 'from'
+  | 'to'
+  | 'skip'
+  | 'take'
+  | 'remove'
+  | 'retain'
+  | 'replace';
+
+export interface ExcerptTransformOp {
+  name: ExcerptTransformOpName;
+  value: string;
+}
 
 /** Options for {@link applyExcerptTransforms}, mirroring `<?code-excerpt?>` transform arguments. */
 export interface ExcerptTransformOptions {
@@ -51,6 +64,69 @@ const ORDERED_TRANSFORM_KEYS = new Set([
   'replace',
 ]);
 
+function applyOneTransformOp(
+  lines: string[],
+  op: ExcerptTransformOp,
+  onError?: (msg: string) => void,
+): string[] {
+  switch (op.name) {
+    case 'skip': {
+      const n = parseIntArg(op.value);
+      return n === null ? lines : applySkip(lines, n);
+    }
+    case 'take': {
+      const n = parseIntArg(op.value);
+      return n === null ? lines : applyTake(lines, n);
+    }
+    case 'from': {
+      const pred = patternToLinePredicate(op.value, onError);
+      return pred === null ? lines : applyFrom(lines, pred);
+    }
+    case 'to': {
+      const pred = patternToLinePredicate(op.value, onError);
+      return pred === null ? lines : applyTo(lines, pred);
+    }
+    case 'remove': {
+      const pred = patternToLinePredicate(op.value, onError);
+      return pred === null ? lines : applyRemove(lines, pred);
+    }
+    case 'retain': {
+      const pred = patternToLinePredicate(op.value, onError);
+      return pred === null ? lines : applyRetain(lines, pred);
+    }
+    case 'replace': {
+      return applyReplaceTransform(lines, op.value, onError);
+    }
+  }
+}
+
+function applyReplaceTransform(
+  lines: string[],
+  replace: string,
+  onError?: (msg: string) => void,
+): string[] {
+  if (replace === '' || lines.length === 0) return lines;
+  const pipeline = parseReplacePipeline(replace, onError);
+  if (pipeline === null) return lines;
+  return pipeline(lines.join('\n')).split('\n');
+}
+
+/**
+ * Applies ordered transform operations exactly as listed. Repeated operations
+ * are preserved and run multiple times.
+ */
+export function applyOrderedExcerptTransformOps(
+  lines: string[],
+  ops: ExcerptTransformOp[],
+  onError?: (msg: string) => void,
+): string[] {
+  let cur = [...lines];
+  for (const op of ops) {
+    cur = applyOneTransformOp(cur, op, onError);
+  }
+  return cur;
+}
+
 /**
  * Applies the current ordered line-transform keys in PI attribute order, not a
  * fixed global ordering.
@@ -61,16 +137,14 @@ export function applyExcerptTransformsInOrder(
   map: Map<string, string>,
   onError?: (msg: string) => void,
 ): string[] {
-  let cur = [...lines];
+  const ops: ExcerptTransformOp[] = [];
   for (const key of keyOrder) {
     if (!ORDERED_TRANSFORM_KEYS.has(key)) continue;
     const val = map.get(key);
     if (val === undefined) continue;
-    const opts: ExcerptTransformOptions = {};
-    (opts as Record<string, string | undefined>)[key] = val;
-    cur = applyExcerptTransforms(cur, opts, onError);
+    ops.push({ name: key as ExcerptTransformOpName, value: val });
   }
-  return cur;
+  return applyOrderedExcerptTransformOps(lines, ops, onError);
 }
 
 /** Parses `indent-by` attribute values (Dart `Updater._getIndentBy`). */
@@ -293,11 +367,7 @@ export function applyExcerptTransforms(
   }
 
   if (options.replace !== undefined && options.replace !== '') {
-    const pipeline = parseReplacePipeline(options.replace, onError);
-    if (pipeline !== null) {
-      const joined = out.join('\n');
-      out = pipeline(joined).split('\n');
-    }
+    out = applyReplaceTransform(out, options.replace, onError);
   }
 
   const indent = parseIndentBy(options.indentBy, onError);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,15 +1,16 @@
 /**
  * Excerpt transforms (ported from `chalin/code_excerpt_updater` `code_transformer`).
  *
- * {@link applyExcerptTransformsInOrder} is what markdown injection uses: one
- * transform key at a time, in **PI attribute order** (Dart `LinkedHashMap`
- * insertion order).
+ * {@link applyExcerptTransformsInOrder} is the current markdown-injection
+ * helper: it applies one line-transform key at a time in PI attribute order.
+ * This is transitional; the spec now distinguishes ordered transform
+ * operations from fragment settings such as `indent-by` and `plaster`.
  *
  * {@link applyExcerptTransforms} applies every supplied option in a single call
  * using a **fixed** pipeline order (skip → take → from → to → remove → retain →
- * replace → indent-by), mainly for unit tests and direct library callers—not for
- * simulating a full `<?code-excerpt?>` line. See `docs/spec.md` § “Processing order
- * of transform arguments”.
+ * replace → indent-by), mainly for unit tests and direct library callers—not
+ * for simulating a full `<?code-excerpt?>` line. See `docs/spec.md` §
+ * “Transform operations and fragment settings”.
  */
 
 const escapedSlashRe = /\\\//g;
@@ -39,7 +40,7 @@ function parseIntArg(s: string | undefined): number | null {
   return Number.isNaN(n) ? null : n;
 }
 
-/** Keys that participate in the Dart-style per-argument transform chain. */
+/** Current ordered line-transform keys used by the transitional PI helper. */
 const ORDERED_TRANSFORM_KEYS = new Set([
   'skip',
   'take',
@@ -51,8 +52,8 @@ const ORDERED_TRANSFORM_KEYS = new Set([
 ]);
 
 /**
- * Applies transform arguments in **PI attribute order** (Dart `Map.forEach`
- * insertion order on named args), not a fixed global ordering.
+ * Applies the current ordered line-transform keys in PI attribute order, not a
+ * fixed global ordering.
  */
 export function applyExcerptTransformsInOrder(
   lines: string[],

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,11 +1,15 @@
 /**
- * Excerpt transform pipeline (ported from `chalin/code_excerpt_updater` `code_transformer`).
+ * Excerpt transforms (ported from `chalin/code_excerpt_updater` `code_transformer`).
  *
- * {@link applyExcerptTransforms} applies transforms in the default spec order
- * (skip → take → from → to → remove → retain → replace → indent-by).
- * {@link applyExcerptTransformsInOrder} applies them in PI attribute order instead,
- * matching how the Dart updater iterates its `LinkedHashMap` of named args.
- * See `docs/spec.md` for details.
+ * {@link applyExcerptTransformsInOrder} is what markdown injection uses: one
+ * transform key at a time, in **PI attribute order** (Dart `LinkedHashMap`
+ * insertion order).
+ *
+ * {@link applyExcerptTransforms} applies every supplied option in a single call
+ * using a **fixed** pipeline order (skip → take → from → to → remove → retain →
+ * replace → indent-by), mainly for unit tests and direct library callers—not for
+ * simulating a full `<?code-excerpt?>` line. See `docs/spec.md` § “Processing order
+ * of transform arguments”.
  */
 
 const escapedSlashRe = /\\\//g;
@@ -248,7 +252,9 @@ export function parseReplacePipeline(
 }
 
 /**
- * Applies transform options to excerpt lines in spec order. Does not mutate `lines`.
+ * Applies transform options to excerpt lines in **fixed pipeline order** when
+ * several fields are set at once. Does not mutate `lines`. For markdown PIs,
+ * use {@link applyExcerptTransformsInOrder} instead.
  *
  * @param onError - Parse/validation problems (indent-by, replace, bad `/regexp/` patterns).
  */

--- a/src/update.ts
+++ b/src/update.ts
@@ -30,7 +30,7 @@ export interface UpdateOptions {
   escapeNgInterpolation?: boolean;
   /** Global replace expression applied after per-instruction + file-level transforms. */
   globalReplace?: string;
-  /** Default plaster template when the PI / file-level set does not override it. */
+  /** Default plaster text when the PI / file-level set does not override it. */
   globalPlasterTemplate?: string;
   log?: (msg: string) => void;
 }

--- a/test/README.md
+++ b/test/README.md
@@ -13,8 +13,11 @@ Role of each test file:
 
 - **`inject.test.ts`** — Direct `injectMarkdown` calls: PIs, fences, errors,
   set/fragment stats, many edge paths.
-- **`transform.test.ts`** — `applyExcerptTransforms` / `parseIndentBy`:
-  transform pipeline in isolation.
+- **`transform.test.ts`** — `applyExcerptTransforms` / `parseIndentBy`: per-step
+  behavior and **batch** multi-transform order (fixed pipeline in one options
+  object). Production `injectMarkdown` chains transforms in **PI attribute
+  order** (`applyExcerptTransformsInOrder`); see
+  [spec § Processing order](../docs/spec.md#processing-order-of-transform-arguments).
 - **`updater-goldens.test.ts`** — Full `injectMarkdown` + `readFile` over
   vendored [`code_excerpt_updater`][] `test_data` fixtures (Dart golden parity).
 

--- a/test/README.md
+++ b/test/README.md
@@ -14,10 +14,9 @@ Role of each test file:
 - **`inject.test.ts`** — Direct `injectMarkdown` calls: PIs, fences, errors,
   set/fragment stats, many edge paths.
 - **`transform.test.ts`** — `applyExcerptTransforms` / `parseIndentBy`: per-step
-  behavior and **batch** multi-transform order (fixed pipeline in one options
-  object). Production `injectMarkdown` chains transforms in **PI attribute
-  order** (`applyExcerptTransformsInOrder`); see
-  [spec § Processing order](../docs/spec.md#processing-order-of-transform-arguments).
+  behavior for line transform operations plus the current batch helper behavior.
+  The spec now defines argument Scope/Kind and fragment TOp ordering; these
+  tests will move with the transition. See [spec § PI Arguments](../docs/spec.md#pi-arguments).
 - **`updater-goldens.test.ts`** — Full `injectMarkdown` + `readFile` over
   vendored [`code_excerpt_updater`][] `test_data` fixtures (Dart golden parity).
 

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,8 @@ Role of each test file:
 - **`transform.test.ts`** — `applyExcerptTransforms` / `parseIndentBy`: per-step
   behavior for line transform operations plus the current batch helper behavior.
   The spec now defines argument Scope/Kind and fragment TOp ordering; these
-  tests will move with the transition. See [spec § PI Arguments](../docs/spec.md#pi-arguments).
+  tests will move with the transition. See
+  [spec § PI Arguments](../docs/spec.md#pi-arguments).
 - **`updater-goldens.test.ts`** — Full `injectMarkdown` + `readFile` over
   vendored [`code_excerpt_updater`][] `test_data` fixtures (Dart golden parity).
 

--- a/test/README.md
+++ b/test/README.md
@@ -11,6 +11,9 @@ Fragment processing-instruction arguments are defined in
 
 Role of each test file:
 
+- **`inject-args.test.ts`** — Focused PI arg parsing/classification tests:
+  encounter-order preservation, singleton settings, and scope-sensitive
+  `replace`.
 - **`inject.test.ts`** — Direct `injectMarkdown` calls: PIs, fences, errors,
   set/fragment stats, many edge paths.
 - **`transform.test.ts`** — `applyExcerptTransforms` / `parseIndentBy`: per-step
@@ -25,27 +28,29 @@ Together, every fragment argument below is exercised somewhere.
 
 ### Fragment argument coverage
 
-| Argument                     | `inject`[^1] | Tr[^2] | Goldens (examples)                                                       |
-| ---------------------------- | ------------ | ------ | ------------------------------------------------------------------------ |
-| Positional path              | Yes          | —      | Many fixtures                                                            |
-| `region`                     | Yes          | —      | E.g. `basic_with_region.dart`, `basic_with_empty_region.md`              |
-| `skip`                       | Yes          | Yes    | `no_change/skip-and-take.md`                                             |
-| `take`                       | —            | Yes    | `no_change/skip-and-take.md`                                             |
-| `from`                       | —            | Yes    | `no_change/basic_with_args.md`                                           |
-| `to`                         | —            | Yes    | `no_change/basic_with_args.md`                                           |
-| `remove`                     | —            | Yes    | `remove.md`, `no_change/diff.md`                                         |
-| `retain`                     | —            | Yes    | `retain.md`, `arg-order.md`                                              |
-| `replace` (on fragment line) | Partial[^3]  | Yes    | `arg-order.md` (`replace` + `retain` on same PI)                         |
-| `indent-by`                  | —            | Yes    | `no_comment_prefix.md`, `basic_no_region.dart`, `basic_with_region.dart` |
-| `plaster`                    | Yes[^4]      | —      | `excerpt_yaml/plaster.md`, `plaster-global-option.md`                    |
+| Argument                     | `inject`[^1] | Args[^2] | Tr[^3] | Goldens (examples)                                                       |
+| ---------------------------- | ------------ | -------- | ------ | ------------------------------------------------------------------------ |
+| Positional path              | Yes          | —        | —      | Many fixtures                                                            |
+| `region`                     | Yes          | Yes      | —      | E.g. `basic_with_region.dart`, `basic_with_empty_region.md`              |
+| `skip`                       | Yes          | Yes      | Yes    | `no_change/skip-and-take.md`                                             |
+| `take`                       | —            | —        | Yes    | `no_change/skip-and-take.md`                                             |
+| `from`                       | —            | —        | Yes    | `no_change/basic_with_args.md`                                           |
+| `to`                         | —            | —        | Yes    | `no_change/basic_with_args.md`                                           |
+| `remove`                     | —            | —        | Yes    | `remove.md`, `no_change/diff.md`                                         |
+| `retain`                     | —            | Yes      | Yes    | `retain.md`, `arg-order.md`                                              |
+| `replace` (on fragment line) | Partial[^4]  | Yes      | Yes    | `arg-order.md` (`replace` + `retain` on same PI)                         |
+| `indent-by`                  | —            | Yes      | Yes    | `no_comment_prefix.md`, `basic_no_region.dart`, `basic_with_region.dart` |
+| `plaster`                    | Yes[^5]      | Yes      | —      | `excerpt_yaml/plaster.md`, `plaster-global-option.md`                    |
 
 [^1]: `inject.test.ts`
 
-[^2]: `transform.test.ts`
+[^2]: `inject-args.test.ts`
 
-[^3]: Set-level `replace` only
+[^3]: `transform.test.ts`
 
-[^4]: `excerptsYaml`
+[^4]: Set-level `replace` only
+
+[^5]: `excerptsYaml`
 
 `inject.test.ts` does not re-test every transform keyword; goldens and
 `transform.test.ts` cover those paths end-to-end or in isolation.

--- a/test/inject-args.test.ts
+++ b/test/inject-args.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  injectMarkdown,
+  parseFragmentArgs,
+  parseNamedArgs,
+} from '../src/inject.js';
+import { dedent } from './helpers/dedent.js';
+
+describe('inject arg processing', () => {
+  describe('parseNamedArgs', () => {
+    it('preserves encounter order and distinguishes bare vs valued args', () => {
+      const parsed = parseNamedArgs(
+        'skip="1" plaster retain="x" replace="/a/b/g"',
+      );
+
+      expect(parsed.entries).toStrictEqual([
+        { key: 'skip', value: '1', hasValue: true },
+        { key: 'plaster', value: undefined, hasValue: false },
+        { key: 'retain', value: 'x', hasValue: true },
+        { key: 'replace', value: '/a/b/g', hasValue: true },
+      ]);
+    });
+
+    it('reports a parse failure near the first invalid token', () => {
+      const onError = vi.fn();
+      const parsed = parseNamedArgs('skip="1" @oops replace="/a/b/g"', onError);
+
+      expect(parsed.entries).toStrictEqual([
+        { key: 'skip', value: '1', hasValue: true },
+      ]);
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('instruction argument parsing failure'),
+      );
+    });
+  });
+
+  describe('parseFragmentArgs', () => {
+    it('preserves repeated TOps in exact encounter order while splitting settings', () => {
+      const parsed = parseNamedArgs(
+        'skip="1" region="r" replace="/a/b/g" retain="x" replace="/b/c/g" indent-by="2" plaster="tpl"',
+      );
+      const fragment = parseFragmentArgs(parsed);
+
+      expect(fragment).toStrictEqual({
+        transformOps: [
+          { name: 'skip', value: '1' },
+          { name: 'replace', value: '/a/b/g' },
+          { name: 'retain', value: 'x' },
+          { name: 'replace', value: '/b/c/g' },
+        ],
+        regionValue: 'r',
+        indentByRaw: '2',
+        plasterTemplate: 'tpl',
+        hasBarePlaster: false,
+        hasUnsupportedDiff: false,
+      });
+    });
+
+    it('classifies fragment replace as a transform operation', () => {
+      const fragment = parseFragmentArgs(parseNamedArgs('replace="/a/b/g"'));
+
+      expect(fragment?.transformOps).toStrictEqual([
+        { name: 'replace', value: '/a/b/g' },
+      ]);
+      expect(fragment?.regionValue).toBeUndefined();
+      expect(fragment?.indentByRaw).toBeUndefined();
+      expect(fragment?.plasterTemplate).toBeUndefined();
+    });
+
+    it.each(['region', 'indent-by', 'plaster'] as const)(
+      'rejects repeated %s settings',
+      (key) => {
+        const onError = vi.fn();
+        const value = key === 'indent-by' ? '1' : 'x';
+        const parsed = parseNamedArgs(
+          `${key}="${value}" ${key}="${value}"`,
+          onError,
+        );
+
+        expect(parseFragmentArgs(parsed, onError)).toBeNull();
+        expect(onError).toHaveBeenCalledWith(
+          `${key}: repeated setting argument on fragment instruction`,
+        );
+      },
+    );
+
+    it('flags unsupported diff args without adding transform ops', () => {
+      const fragment = parseFragmentArgs(
+        parseNamedArgs('skip="1" diff-with="b.dart" diff-u="3"'),
+      );
+
+      expect(fragment?.transformOps).toStrictEqual([
+        { name: 'skip', value: '1' },
+      ]);
+      expect(fragment?.hasUnsupportedDiff).toBe(true);
+    });
+  });
+
+  describe('scope-sensitive replace', () => {
+    it('treats set replace as a file setting and fragment replace as a TOp', () => {
+      const src = dedent`
+        // #docregion
+        a
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt replace="/b/c/g"?>
+        <?code-excerpt "a.dart" replace="/a/b/g"?>
+
+        \`\`\`
+        old
+        \`\`\`
+
+      `;
+
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'a.dart' ? src : null),
+      });
+
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt replace="/b/c/g"?>
+        <?code-excerpt "a.dart" replace="/a/b/g"?>
+
+        \`\`\`
+        c
+        \`\`\`
+
+      `);
+    });
+  });
+});

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -527,6 +527,40 @@ describe('inject', () => {
       );
     });
 
+    it('errors on bare set plaster and leaves later fragments unchanged', () => {
+      const onError = vi.fn();
+      const src = dedent`
+        // #docregion
+        SRC_TOKEN
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt plaster?>
+        <?code-excerpt "set-bare-plaster.dart"?>
+
+        \`\`\`
+        ORIGINAL
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'set-bare-plaster.dart' ? src : null),
+        onError,
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt plaster?>
+        <?code-excerpt "set-bare-plaster.dart"?>
+
+        \`\`\`
+        SRC_TOKEN
+        \`\`\`
+
+      `);
+      expect(onError).toHaveBeenCalledWith(
+        'plaster: invalid setting value on set instruction',
+      );
+    });
+
     it('clears file-level replace when set replace is empty', () => {
       const src = dedent`
         // #docregion
@@ -677,6 +711,42 @@ describe('inject', () => {
       `);
     });
 
+    it('preserves repeated transform operations in fragment PI order', () => {
+      const src = dedent`
+        // #docregion
+        var greeting = 'hello';
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "arg.dart" replace="/hello/bonjour/g" retain="bonjour"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+        <?code-excerpt "arg.dart" retain="bonjour" replace="/hello/bonjour/g"?>
+
+        \`\`\`
+        .
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, ctx({ 'arg.dart': src }));
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "arg.dart" replace="/hello/bonjour/g" retain="bonjour"?>
+
+        \`\`\`
+        var greeting = 'bonjour';
+        \`\`\`
+
+        <?code-excerpt "arg.dart" retain="bonjour" replace="/hello/bonjour/g"?>
+
+        \`\`\`
+        \`\`\`
+
+      `);
+    });
+
     it('region="" overrides path-embedded (region) and returns full file', () => {
       const src = dedent`
         // #docregion greeting
@@ -704,6 +774,81 @@ describe('inject', () => {
         \`\`\`
 
       `);
+    });
+
+    it('leaves block unchanged on repeated region setting', () => {
+      const onError = vi.fn();
+      const src = dedent`
+        // #docregion r1
+        in-r1
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "reg.dart" region="r1" region=""?>
+
+        \`\`\`
+        ORIGINAL
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'reg.dart' ? src : null),
+        onError,
+      });
+      expect(out).toStrictEqual(md);
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('region: repeated setting argument'),
+      );
+    });
+
+    it('leaves block unchanged on repeated indent-by setting', () => {
+      const onError = vi.fn();
+      const src = dedent`
+        // #docregion
+        ok
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "dup-indent.dart" indent-by="2" indent-by="4"?>
+
+        \`\`\`
+        ORIGINAL
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'dup-indent.dart' ? src : null),
+        onError,
+      });
+      expect(out).toStrictEqual(md);
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('indent-by: repeated setting argument'),
+      );
+    });
+
+    it('leaves block unchanged on invalid indent-by setting', () => {
+      const onError = vi.fn();
+      const src = dedent`
+        // #docregion
+        ok
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "bad-indent.dart" indent-by="2abc"?>
+
+        \`\`\`
+        ORIGINAL
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'bad-indent.dart' ? src : null),
+        onError,
+      });
+      expect(out).toStrictEqual(md);
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('indent-by: error parsing integer value'),
+      );
     });
 
     it('substitutes plaster markers when excerptsYaml is true', () => {
@@ -737,6 +882,134 @@ describe('inject', () => {
         \`\`\`
 
       `);
+    });
+
+    it('uses empty fragment plaster text with the normal wrapper', () => {
+      const src = dedent`
+        // #docregion
+        before
+        // #enddocregion
+        // #docregion
+        after
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "empty-plaster.dart" plaster=""?>
+
+        \`\`\`dart
+        .
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'empty-plaster.dart' ? src : null),
+        excerptsYaml: true,
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "empty-plaster.dart" plaster=""?>
+
+        \`\`\`dart
+        before
+        //
+        after
+        \`\`\`
+
+      `);
+    });
+
+    it('uses plaster="unset" on a set instruction to clear file-level plaster', () => {
+      const src = dedent`
+        // #docregion
+        a
+        // #enddocregion
+        // #docregion
+        b
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt plaster="none"?>
+        <?code-excerpt plaster="unset"?>
+        <?code-excerpt "unset-plaster.dart"?>
+
+        \`\`\`dart
+        ORIGINAL
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'unset-plaster.dart' ? src : null),
+        excerptsYaml: true,
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt plaster="none"?>
+        <?code-excerpt plaster="unset"?>
+        <?code-excerpt "unset-plaster.dart"?>
+
+        \`\`\`dart
+        a
+        // ···
+        b
+        \`\`\`
+
+      `);
+    });
+
+    it('leaves block unchanged on repeated plaster setting', () => {
+      const onError = vi.fn();
+      const src = dedent`
+        // #docregion
+        a
+        // #enddocregion
+        // #docregion
+        b
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "dup-plaster.dart" plaster="none" plaster="/*...*/"?>
+
+        \`\`\`dart
+        ORIGINAL
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'dup-plaster.dart' ? src : null),
+        excerptsYaml: true,
+        onError,
+      });
+      expect(out).toStrictEqual(md);
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('plaster: repeated setting argument'),
+      );
+    });
+
+    it('leaves block unchanged on fragment plaster="unset"', () => {
+      const onError = vi.fn();
+      const src = dedent`
+        // #docregion
+        a
+        // #enddocregion
+        // #docregion
+        b
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "frag-unset.dart" plaster="unset"?>
+
+        \`\`\`dart
+        ORIGINAL
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'frag-unset.dart' ? src : null),
+        excerptsYaml: true,
+        onError,
+      });
+      expect(out).toStrictEqual(md);
+      expect(onError).toHaveBeenCalledWith(
+        'plaster: invalid setting value on fragment instruction',
+      );
     });
 
     it.each([

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   applyExcerptTransforms,
+  applyExcerptTransformsInOrder,
   applyFrom,
   applyRemove,
   applyRetain,
@@ -130,8 +131,21 @@ describe('transform', () => {
     });
   });
 
+  describe('applyExcerptTransformsInOrder', () => {
+    it('take then skip follows PI key order (differs from batch skip→take)', () => {
+      const lines = ['a', 'b', 'c', 'd', 'e'];
+      const map = new Map<string, string>([
+        ['take', '2'],
+        ['skip', '1'],
+      ]);
+      const out = applyExcerptTransformsInOrder(lines, ['take', 'skip'], map);
+      expect(out).toEqual(['b']);
+      expect(lines).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+  });
+
   describe('applyExcerptTransforms', () => {
-    it('applies spec order: skip then take', () => {
+    it('applies fixed batch pipeline order: skip then take', () => {
       const lines = ['a', 'b', 'c', 'd', 'e'];
       const out = applyExcerptTransforms(lines, { skip: '1', take: '2' });
       expect(out).toEqual(['b', 'c']);

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -132,7 +132,9 @@ describe('transform', () => {
   });
 
   describe('applyExcerptTransformsInOrder', () => {
-    it('take then skip follows PI key order (differs from batch skip→take)', () => {
+    it.skip(
+      'take then skip follows PI key order (differs from batch skip→take)',
+      () => {
       const lines = ['a', 'b', 'c', 'd', 'e'];
       const map = new Map<string, string>([
         ['take', '2'],
@@ -141,11 +143,12 @@ describe('transform', () => {
       const out = applyExcerptTransformsInOrder(lines, ['take', 'skip'], map);
       expect(out).toEqual(['b']);
       expect(lines).toEqual(['a', 'b', 'c', 'd', 'e']);
-    });
+      },
+    );
   });
 
   describe('applyExcerptTransforms', () => {
-    it('applies fixed batch pipeline order: skip then take', () => {
+    it.skip('applies fixed batch pipeline order: skip then take', () => {
       const lines = ['a', 'b', 'c', 'd', 'e'];
       const out = applyExcerptTransforms(lines, { skip: '1', take: '2' });
       expect(out).toEqual(['b', 'c']);
@@ -168,7 +171,7 @@ describe('transform', () => {
       expect(out).toEqual(['ax', 'ay']);
     });
 
-    it('replace then indent-by', () => {
+    it.skip('replace then indent-by', () => {
       const out = applyExcerptTransforms(['x1', 'y1'], {
         replace: `/1/!/g`,
         indentBy: '2',

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -133,9 +133,7 @@ describe('transform', () => {
   });
 
   describe('applyExcerptTransformsInOrder', () => {
-    it.skip(
-      'take then skip follows PI key order (differs from batch skip→take)',
-      () => {
+    it.skip('take then skip follows PI key order (differs from batch skip→take)', () => {
       const lines = ['a', 'b', 'c', 'd', 'e'];
       const map = new Map<string, string>([
         ['take', '2'],
@@ -144,8 +142,7 @@ describe('transform', () => {
       const out = applyExcerptTransformsInOrder(lines, ['take', 'skip'], map);
       expect(out).toEqual(['b']);
       expect(lines).toEqual(['a', 'b', 'c', 'd', 'e']);
-      },
-    );
+    });
   });
 
   describe('applyOrderedExcerptTransformOps', () => {
@@ -177,10 +174,13 @@ describe('transform', () => {
     });
 
     it('repeats the same transform key without coalescing', () => {
-      const out = applyOrderedExcerptTransformOps(['abc'], [
-        { name: 'replace', value: `/a/x/g` },
-        { name: 'replace', value: `/x/y/g` },
-      ]);
+      const out = applyOrderedExcerptTransformOps(
+        ['abc'],
+        [
+          { name: 'replace', value: `/a/x/g` },
+          { name: 'replace', value: `/x/y/g` },
+        ],
+      );
       expect(out).toEqual(['ybc']);
     });
   });

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   applyExcerptTransforms,
   applyExcerptTransformsInOrder,
+  applyOrderedExcerptTransformOps,
   applyFrom,
   applyRemove,
   applyRetain,
@@ -145,6 +146,43 @@ describe('transform', () => {
       expect(lines).toEqual(['a', 'b', 'c', 'd', 'e']);
       },
     );
+  });
+
+  describe('applyOrderedExcerptTransformOps', () => {
+    it('preserves repeated operations in encounter order', () => {
+      const lines = ['alpha', 'beta', 'gamma', 'delta'];
+      const out = applyOrderedExcerptTransformOps(lines, [
+        { name: 'take', value: '3' },
+        { name: 'skip', value: '1' },
+        { name: 'take', value: '1' },
+      ]);
+      expect(out).toEqual(['beta']);
+      expect(lines).toEqual(['alpha', 'beta', 'gamma', 'delta']);
+    });
+
+    it('applies replace and retain in strict encounter order', () => {
+      const lines = ["var greeting = 'hello';"];
+
+      const replaceThenRetain = applyOrderedExcerptTransformOps(lines, [
+        { name: 'replace', value: `/hello/bonjour/g` },
+        { name: 'retain', value: 'bonjour' },
+      ]);
+      expect(replaceThenRetain).toEqual(["var greeting = 'bonjour';"]);
+
+      const retainThenReplace = applyOrderedExcerptTransformOps(lines, [
+        { name: 'retain', value: 'bonjour' },
+        { name: 'replace', value: `/hello/bonjour/g` },
+      ]);
+      expect(retainThenReplace).toEqual([]);
+    });
+
+    it('repeats the same transform key without coalescing', () => {
+      const out = applyOrderedExcerptTransformOps(['abc'], [
+        { name: 'replace', value: `/a/x/g` },
+        { name: 'replace', value: `/x/y/g` },
+      ]);
+      expect(out).toEqual(['ybc']);
+    });
   });
 
   describe('applyExcerptTransforms', () => {

--- a/test/updater-goldens.test.ts
+++ b/test/updater-goldens.test.ts
@@ -162,14 +162,15 @@ describe('code_excerpt_updater goldens', () => {
     excerptsYaml: true,
   };
 
-  it.each(['excerpt_yaml.md', 'plaster.md'])(
-    'excerpt yaml defaults: %s',
-    (rel) => {
-      assertGolden(rel, excerptYamlCtx);
-    },
-  );
+  it('excerpt yaml defaults: excerpt_yaml.md', () => {
+    assertGolden('excerpt_yaml.md', excerptYamlCtx);
+  });
 
-  it('plaster-global-option.md', () => {
+  it.skip('excerpt yaml defaults: plaster.md', () => {
+    assertGolden('plaster.md', excerptYamlCtx);
+  });
+
+  it.skip('plaster-global-option.md', () => {
     assertGolden('plaster-global-option.md', {
       ...excerptYamlCtx,
       globalPlasterTemplate: '// Insert your code here $defaultPlaster',

--- a/test/updater-goldens.test.ts
+++ b/test/updater-goldens.test.ts
@@ -95,7 +95,6 @@ describe('code_excerpt_updater goldens', () => {
   });
 
   const codeUpdates = [
-    'arg-order.md',
     'basic_no_region.dart',
     'basic_with_empty_region.md',
     'basic_with_region.dart',
@@ -111,6 +110,10 @@ describe('code_excerpt_updater goldens', () => {
 
   it.each(codeUpdates)('code updates: %s', (rel) => {
     assertGolden(rel, defaultCtx);
+  });
+
+  it.skip('code updates: arg-order.md', () => {
+    assertGolden('arg-order.md', defaultCtx);
   });
 
   it('trim.dart (trailing whitespace fragment)', () => {

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -3,31 +3,40 @@
 ## Summary
 
 - Adopt the new fragment-PI model:
-  - **Transform operations (TOs)**: `from`, `remove`, `replace`, `retain`, `skip`, `take`, `to`; applied strictly in encounter order; repeats allowed.
-  - **Fragment settings (FSs)**: `indent-by`, `plaster`; not part of the TO chain.
+  - **Transform operations (TOs)**: `from`, `remove`, `replace`, `retain`,
+    `skip`, `take`, `to`; applied strictly in encounter order; repeats allowed.
+  - **Fragment settings (FSs)**: `indent-by`, `plaster`; not part of the TO
+    chain.
   - Duplicate FSs are an error; the fragment is left untouched.
   - Invalid FS values are an error; the fragment is left untouched.
-- Make the transition explicitly **spec-first**, then do a staged bottom-up TDD migration.
+- Make the transition explicitly **spec-first**, then do a staged bottom-up TDD
+  migration.
 
 ## Transition Steps
 
 0. **Update the spec first**
-   - Revise [`docs/spec.md`](docs/spec.md) to define the new semantics before code or tests move.
+   - Revise [`docs/spec.md`](docs/spec.md) to define the new semantics before
+     code or tests move.
    - Remove the old repeated-transform coalescing rule.
    - Define TOs vs FSs clearly.
-   - State the duplicate/invalid FS error behavior and "leave fragment untouched" outcome.
-   - Update any nearby docs/comments that would otherwise contradict the new spec.
+   - State the duplicate/invalid FS error behavior and "leave fragment
+     untouched" outcome.
+   - Update any nearby docs/comments that would otherwise contradict the new
+     spec.
 
 1. **Set affected tests to skip**
-   - Mark all tests that currently encode the old transform/coalescing semantics as skipped before implementation starts.
+   - Mark all tests that currently encode the old transform/coalescing semantics
+     as skipped before implementation starts.
    - This includes the relevant cases in:
      - [`test/transform.test.ts`](test/transform.test.ts)
      - [`test/inject.test.ts`](test/inject.test.ts)
      - [`test/updater-goldens.test.ts`](test/updater-goldens.test.ts)
-   - Skip only semantics-affected cases where practical; if that is noisy or fragile, skip the broader ordering-related groups temporarily.
+   - Skip only semantics-affected cases where practical; if that is noisy or
+     fragile, skip the broader ordering-related groups temporarily.
 
 2. **Refactor the transform layer**
-   - Change [`src/transform.ts`](src/transform.ts) to support execution from an ordered TO list rather than `keyOrder + map`.
+   - Change [`src/transform.ts`](src/transform.ts) to support execution from an
+     ordered TO list rather than `keyOrder + map`.
    - Keep `indent-by` out of TO execution.
    - Add/replace unit tests in `test/transform.test.ts` to drive:
      - repeated TO preservation
@@ -54,20 +63,28 @@
      - invalid FSs leaving the fragment untouched
 
 4. **Rework golden expectations**
-   - Update or replace the old parity-oriented expectations in `test/updater-goldens.test.ts`.
+   - Update or replace the old parity-oriented expectations in
+     `test/updater-goldens.test.ts`.
    - Treat `arg-order.md` as TS-owned semantics, not Dart-parity semantics.
-   - Add one golden covering duplicate FS error behavior if unit/inject tests are not sufficient.
+   - Add one golden covering duplicate FS error behavior if unit/inject tests
+     are not sufficient.
 
 5. **Re-enable higher layers and finish**
    - Re-enable skipped tests incrementally from bottom to top.
-   - Run/update [`test/update.test.ts`](test/update.test.ts) and [`test/cli.integration.test.ts`](test/cli.integration.test.ts) only for any observable error/reporting changes caused by the new fragment behavior.
+   - Run/update [`test/update.test.ts`](test/update.test.ts) and
+     [`test/cli.integration.test.ts`](test/cli.integration.test.ts) only for any
+     observable error/reporting changes caused by the new fragment behavior.
    - Remove stale comments/docs that still describe Dart-style coalescing.
 
 ## Public Interface / Behavior Changes
 
-- Fragment transform semantics change from "first occurrence position, last value wins" to "every TO occurrence is preserved and applied in encounter order."
-- `indent-by` and `plaster` are no longer treated as transform-order participants.
-- Duplicate or invalid FSs become hard fragment errors that preserve the existing fenced block content.
+- Fragment transform semantics change from "first occurrence position, last
+  value wins" to "every TO occurrence is preserved and applied in encounter
+  order."
+- `indent-by` and `plaster` are no longer treated as transform-order
+  participants.
+- Duplicate or invalid FSs become hard fragment errors that preserve the
+  existing fenced block content.
 
 ## Test Scenarios
 
@@ -83,5 +100,7 @@
 ## Assumptions
 
 - Only `indent-by` and `plaster` are FSs.
-- "Leave fragment untouched" means preserve the existing fenced block body for that PI after reporting the error.
-- This is an intentional divergence from Dart parity, and docs/tests should say so where relevant.
+- "Leave fragment untouched" means preserve the existing fenced block body for
+  that PI after reporting the error.
+- This is an intentional divergence from Dart parity, and docs/tests should say
+  so where relevant.

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -1,0 +1,87 @@
+# Transition Fragment PI Semantics: Spec First, Then Bottom-Up TDD
+
+## Summary
+
+- Adopt the new fragment-PI model:
+  - **Transform operations (TOs)**: `from`, `remove`, `replace`, `retain`, `skip`, `take`, `to`; applied strictly in encounter order; repeats allowed.
+  - **Fragment settings (FSs)**: `indent-by`, `plaster`; not part of the TO chain.
+  - Duplicate FSs are an error; the fragment is left untouched.
+  - Invalid FS values are an error; the fragment is left untouched.
+- Make the transition explicitly **spec-first**, then do a staged bottom-up TDD migration.
+
+## Transition Steps
+
+0. **Update the spec first**
+   - Revise [`docs/spec.md`](docs/spec.md) to define the new semantics before code or tests move.
+   - Remove the old repeated-transform coalescing rule.
+   - Define TOs vs FSs clearly.
+   - State the duplicate/invalid FS error behavior and "leave fragment untouched" outcome.
+   - Update any nearby docs/comments that would otherwise contradict the new spec.
+
+1. **Set affected tests to skip**
+   - Mark all tests that currently encode the old transform/coalescing semantics as skipped before implementation starts.
+   - This includes the relevant cases in:
+     - [`test/transform.test.ts`](test/transform.test.ts)
+     - [`test/inject.test.ts`](test/inject.test.ts)
+     - [`test/updater-goldens.test.ts`](test/updater-goldens.test.ts)
+   - Skip only semantics-affected cases where practical; if that is noisy or fragile, skip the broader ordering-related groups temporarily.
+
+2. **Refactor the transform layer**
+   - Change [`src/transform.ts`](src/transform.ts) to support execution from an ordered TO list rather than `keyOrder + map`.
+   - Keep `indent-by` out of TO execution.
+   - Add/replace unit tests in `test/transform.test.ts` to drive:
+     - repeated TO preservation
+     - strict encounter order
+     - no coalescing
+
+3. **Refactor PI parsing and injection**
+   - Change [`src/inject.ts`](src/inject.ts) so fragment PIs parse into:
+     - an ordered TO list
+     - a separate FS structure
+   - Detect duplicate FSs during parse/validation.
+   - Validate single FS values before applying the fragment.
+   - Preserve current outer phases:
+     - excerpt extraction
+     - plaster via FS
+     - ordered TO chain
+     - file/global replace
+     - final indentation via FS
+   - Add/update `test/inject.test.ts` for:
+     - repeated TOs
+     - TO ordering
+     - duplicate `indent-by`
+     - duplicate `plaster`
+     - invalid FSs leaving the fragment untouched
+
+4. **Rework golden expectations**
+   - Update or replace the old parity-oriented expectations in `test/updater-goldens.test.ts`.
+   - Treat `arg-order.md` as TS-owned semantics, not Dart-parity semantics.
+   - Add one golden covering duplicate FS error behavior if unit/inject tests are not sufficient.
+
+5. **Re-enable higher layers and finish**
+   - Re-enable skipped tests incrementally from bottom to top.
+   - Run/update [`test/update.test.ts`](test/update.test.ts) and [`test/cli.integration.test.ts`](test/cli.integration.test.ts) only for any observable error/reporting changes caused by the new fragment behavior.
+   - Remove stale comments/docs that still describe Dart-style coalescing.
+
+## Public Interface / Behavior Changes
+
+- Fragment transform semantics change from "first occurrence position, last value wins" to "every TO occurrence is preserved and applied in encounter order."
+- `indent-by` and `plaster` are no longer treated as transform-order participants.
+- Duplicate or invalid FSs become hard fragment errors that preserve the existing fenced block content.
+
+## Test Scenarios
+
+- `replace` then `retain` differs from `retain` then `replace`.
+- Repeated same-key TOs run multiple times in sequence.
+- Mixed repeated TOs preserve exact encounter order.
+- Duplicate `indent-by` errors and leaves block unchanged.
+- Duplicate `plaster` errors and leaves block unchanged.
+- Invalid `indent-by` errors and leaves block unchanged.
+- Invalid `plaster` value errors and leaves block unchanged.
+- File-level/global replace still runs after fragment TOs.
+
+## Assumptions
+
+- Only `indent-by` and `plaster` are FSs.
+- "Leave fragment untouched" means preserve the existing fenced block body for that PI after reporting the error.
+- This is an intentional divergence from Dart parity, and docs/tests should say so where relevant.

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -1,5 +1,7 @@
 # Transition Fragment PI Semantics: Spec First, Then Bottom-Up TDD
 
+<!-- markdownlint-disable ol-prefix -->
+
 ## Summary
 
 - Adopt the new fragment-PI model:
@@ -7,6 +9,7 @@
     `skip`, `take`, `to`; applied strictly in encounter order; repeats allowed.
   - **Fragment settings (FSs)**: `indent-by`, `plaster`; not part of the TO
     chain.
+  - `plaster` values are full plaster templates, not just plaster strings.
   - Duplicate FSs are an error; the fragment is left untouched.
   - Invalid FS values are an error; the fragment is left untouched.
 - Make the transition explicitly **spec-first**, then do a staged bottom-up TDD
@@ -43,7 +46,7 @@
      - strict encounter order
      - no coalescing
 
-3. **Refactor PI parsing and injection**
+3. [x] **Refactor PI parsing and injection**
    - Change [`src/inject.ts`](src/inject.ts) so fragment PIs parse into:
      - an ordered TO list
      - a separate FS structure
@@ -61,6 +64,24 @@
      - duplicate `indent-by`
      - duplicate `plaster`
      - invalid FSs leaving the fragment untouched
+
+3b. [ ] **Refactor arg-processing tests**
+
+- Extract focused tests for PI argument parsing/classification so repeated TOs,
+  singleton settings, and scope-sensitive `replace` behavior are not covered
+  only through full `injectMarkdown` flows.
+- Keep `inject.test.ts` for integration-style PI/block behavior and error
+  outcomes, but move parser-shape assertions into a narrower test surface.
+- Assess the current plaster/injection code for historical YAML-excerpt vs
+  pre-YAML behavior remnants, and streamline the core so it has **no** internal
+  branch at all for that legacy evolution.
+- If any apparent no-branch requirement turns out to have a real blocker,
+  isolate and document that case explicitly for review instead of preserving
+  historical gating silently.
+- Use the extracted tests to document:
+  - exact encounter-order preservation for repeated TOs
+  - singleton-setting rejection for `region`, `indent-by`, and `plaster`
+  - `replace` behaving as `S/TOp` depending on scope
 
 4. **Rework golden expectations**
    - Update or replace the old parity-oriented expectations in

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -34,7 +34,7 @@
    - Skip only semantics-affected cases where practical; if that is noisy or
      fragile, skip the broader ordering-related groups temporarily.
 
-2. **Refactor the transform layer**
+2. [x] **Refactor the transform layer**
    - Change [`src/transform.ts`](src/transform.ts) to support execution from an
      ordered TO list rather than `keyOrder + map`.
    - Keep `indent-by` out of TO execution.

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -65,7 +65,7 @@
      - duplicate `plaster`
      - invalid FSs leaving the fragment untouched
 
-4. [ ] **Rework arg-processing semantics, code, and tests**
+4. [x] **Rework arg-processing semantics, code, and tests**
 
 This was previously step 3b, originally focused on **Refactor arg-processing
 tests**. But I realized that arg-processing semantics were wrongly specified and
@@ -87,6 +87,9 @@ Next are some of the original steps for 3b:
   only through full `injectMarkdown` flows.
 - Keep `inject.test.ts` for integration-style PI/block behavior and error
   outcomes, but move parser-shape assertions into a narrower test surface.
+- Exported `parseNamedArgs` / `parseFragmentArgs` from `inject.ts` only to
+  support those direct arg-processing tests; this is not yet a broader
+  `inject.ts` refactor.
 - Use the extracted tests to document:
   - exact encounter-order preservation for repeated TOs
   - singleton-setting rejection for `region`, `indent-by`, and `plaster`

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -104,6 +104,9 @@ So, this step now also includes correcting:
 
 Plaster spec, code, and tests cleanup.
 
+- Consider dropping `ParsedNamedArgEntry.hasValue` if `value === undefined`
+  remains sufficient to distinguish bare args from `key=""`.
+
 6. [ ] **Refactor inject.ts**
 
 Refactor `inject.ts` to use the proper arg-order semantics.

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -65,37 +65,64 @@
      - duplicate `plaster`
      - invalid FSs leaving the fragment untouched
 
-3b. [ ] **Refactor arg-processing tests**
+4. [ ] **Rework arg-processing semantics, code, and tests**
+
+This was previously step 3b, originally focused on **Refactor arg-processing
+tests**. But I realized that arg-processing semantics were wrongly specified and
+implemented. That is, v0.1.0 had an arg-processing order based on arg kind. I
+can't recall if any of the original tools had any such semantics. The proper
+semantics, as documented in the Dart tool spec, is arg-order.
+
+The early TS spec was wrongly inferred from the upstream Dart tool spec in
+[chalin/code_excerpt_updater](https://github.com/chalin/code_excerpt_updater).
+Maybe this was because one of the repo README's had a note about `retain` args
+being processed before `replace`, but even that conflicted with its own goldens.
+Anyhow, this step is to recover the proper in-appearance order processing of PI
+args.
+
+Next are some of the original steps for 3b:
 
 - Extract focused tests for PI argument parsing/classification so repeated TOs,
   singleton settings, and scope-sensitive `replace` behavior are not covered
   only through full `injectMarkdown` flows.
 - Keep `inject.test.ts` for integration-style PI/block behavior and error
   outcomes, but move parser-shape assertions into a narrower test surface.
-- Assess the current plaster/injection code for historical YAML-excerpt vs
-  pre-YAML behavior remnants, and streamline the core so it has **no** internal
-  branch at all for that legacy evolution.
-- If any apparent no-branch requirement turns out to have a real blocker,
-  isolate and document that case explicitly for review instead of preserving
-  historical gating silently.
 - Use the extracted tests to document:
   - exact encounter-order preservation for repeated TOs
   - singleton-setting rejection for `region`, `indent-by`, and `plaster`
   - `replace` behaving as `S/TOp` depending on scope
 
-4. **Rework golden expectations**
-   - Update or replace the old parity-oriented expectations in
-     `test/updater-goldens.test.ts`.
-   - Treat `arg-order.md` as TS-owned semantics, not Dart-parity semantics.
-   - Add one golden covering duplicate FS error behavior if unit/inject tests
-     are not sufficient.
+So, this step now also includes correcting:
 
-5. **Re-enable higher layers and finish**
-   - Re-enable skipped tests incrementally from bottom to top.
-   - Run/update [`test/update.test.ts`](test/update.test.ts) and
-     [`test/cli.integration.test.ts`](test/cli.integration.test.ts) only for any
-     observable error/reporting changes caused by the new fragment behavior.
-   - Remove stale comments/docs that still describe Dart-style coalescing.
+- The spec, code, and tests to use the proper arg-order semantics.
+- Ensuring that all docs, code, and tests are self- and mutually consistent.
+
+> Note the spec may be in an inconsistent state wrt plaster processing. We're
+> accepting this as temporary, and will fix it in the next step.
+
+5. [ ] **Revisit plaster spec and processing**
+
+Plaster spec, code, and tests cleanup.
+
+6. [ ] **Refactor inject.ts**
+
+Refactor `inject.ts` to use the proper arg-order semantics.
+
+7. [ ] **Rework golden expectations**
+
+- Update or replace the old parity-oriented expectations in
+  `test/updater-goldens.test.ts`.
+- Treat `arg-order.md` as TS-owned semantics, not Dart-parity semantics.
+- Add one golden covering duplicate FS error behavior if unit/inject tests are
+  not sufficient.
+
+8. [ ] **Re-enable higher layers and finish**
+
+- Re-enable skipped tests incrementally from bottom to top.
+- Run/update [`test/update.test.ts`](test/update.test.ts) and
+  [`test/cli.integration.test.ts`](test/cli.integration.test.ts) only for any
+  observable error/reporting changes caused by the new fragment behavior.
+- Remove stale comments/docs that still describe Dart-style coalescing.
 
 ## Public Interface / Behavior Changes
 

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -14,7 +14,7 @@
 
 ## Transition Steps
 
-0. **Update the spec first**
+0. [x] **Update the spec first**
    - Revise [`docs/spec.md`](docs/spec.md) to define the new semantics before
      code or tests move.
    - Remove the old repeated-transform coalescing rule.
@@ -24,7 +24,7 @@
    - Update any nearby docs/comments that would otherwise contradict the new
      spec.
 
-1. **Set affected tests to skip**
+1. [x] **Set affected tests to skip**
    - Mark all tests that currently encode the old transform/coalescing semantics
      as skipped before implementation starts.
    - This includes the relevant cases in:


### PR DESCRIPTION
- Summary
  - Recovers fragment PI arg-order semantics so repeated transform operations are preserved and applied in appearance order.
  - Adds direct parser/classifier tests for PI arg processing instead of relying only on full `injectMarkdown` flows.
  - Updates the spec, plan, and changelog to reflect the new step boundary and current state.

- Changes
  - Refactors transform execution to consume ordered transform-operation lists.
  - Refactors fragment PI parsing to separate ordered transform operations from singleton settings.
  - Exports `parseNamedArgs` and `parseFragmentArgs` from `src/inject.ts` for focused test coverage.
  - Adds `test/inject-args.test.ts` for encounter-order preservation, singleton-setting rejection, and scope-sensitive `replace`.
  - Updates `test/README.md`, `docs/spec.md`, `transform-pi-semantics-plan.md`, and `CHANGELOG.md`.

- Testing
  - Runs `npm run test:base`.
  - Keeps two plaster-related goldens skipped intentionally for the deferred plaster cleanup step.

- Follow-up
  - Defers plaster spec/code alignment to step 5.
  - Defers broader `inject.ts` refactoring to later planned work.