### PR TITLE
Clean up plaster template semantics and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog][], and this project adheres to
   [Details](docs/spec.md#processing-order-of-transform-arguments).
 - Fragment PI arg processing now preserves repeated transform operations in
   appearance order instead of coalescing them by key.
+- Plaster handling now uses YAML-style default-template semantics by default,
+  treats explicit `plaster` values as full templates, and documents
+  `plaster="unset"` as unsupported.
 
 ## [v0.1.0][] - 2026-04-13
 

--- a/docs/migration-notes.md
+++ b/docs/migration-notes.md
@@ -7,8 +7,8 @@ This document tracks the migration of the Dart excerpter tooling to TypeScript.
 About the original model:
 
 - From plaster.dart, I see that the `plaster` args were setting
-  `plasterTemplate`; and that `plaster=""` meant "use the lang template
-  default".
+  `plasterTemplate`; and that a `null` plaster template meant "use the lang
+  template default", while `plaster=""` meant an empty plaster template.
 - There was never any capacity for a user to set only, what we've started
   calling, the "plaster string", only the full "plaster template".
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -137,9 +137,7 @@ fragment instructions in the same file. Precedence:
 
 - `indent-by`: overrides global settings
 - `path-base`: appends to the global base directory
-- `plaster`: overrides global settings; `plaster="unset"` clears the file-level
-  plaster template; bare `plaster` is invalid and should be written as
-  `plaster="unset"`
+- `plaster`: overrides global settings; bare `plaster` is invalid
 - `replace`: see [Replace order](#replace-order)
 
 ### Fragment instructions
@@ -156,9 +154,10 @@ Fragment-setting semantics:
   transformations.
 - `plaster="<template>"` sets the full plaster template for the fragment,
   including any language-specific comment wrapper.
+- `plaster=""` sets the plaster template to the empty string.
 - `plaster="none"` ensures that no plaster template is injected into the
   excerpt.
-- `plaster="unset"` and bare `plaster` are invalid in fragment scope.
+- bare `plaster` is invalid in fragment scope.
 - `indent-by` is applied after the excerpt content has been fully transformed.
   Overrides file-level and global settings.
 - Repeating `indent-by` or `plaster` on the same fragment instruction is an
@@ -317,16 +316,13 @@ language-specific comment, for example:
 | CSS, SCSS    | `/* ··· */`     |
 | YAML         | `# ···`         |
 
-Those language-shaped default plaster templates apply when excerpt injection
-runs in **YAML excerpt mode** (`MarkdownInjectContext.excerptsYaml`); otherwise
-the extractor still inserts the raw plaster string `···` between segments and it
-is passed through unchanged (unless overridden or removed via `plaster`).
+When the excerpt language has no known comment syntax, the raw plaster string
+`···` is used.
 
 The `plaster` argument sets the full plaster template, not just the plaster
 string. For example, `plaster="/* $defaultPlaster */"` uses that whole template,
-while `plaster="none"` removes plaster injection. On a set instruction,
-`plaster="unset"` clears the file-level plaster template and falls back to the
-global/default behavior.
+while `plaster="none"` removes plaster injection. The `$defaultPlaster`
+placeholder expands to the default plaster string `···`.
 
 ## Acknowledgments
 

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -89,7 +89,7 @@ export interface MarkdownInjectContext {
   pathBase?: string;
   /**
    * When `true`, applies language-specific plaster comment wrappers in YAML
-   * excerpt mode (default `false`, legacy fragment-style behavior).
+   * excerpt mode (default `true`).
    */
   excerptsYaml?: boolean;
   /** Default extra spaces when `indent-by` is omitted on a fragment directive. */
@@ -428,7 +428,7 @@ export function injectMarkdown(
   const lines = markdown.split('\n');
   const out: string[] = [];
   let pathBase = ctx.pathBase ?? '';
-  const excerptsYaml = ctx.excerptsYaml ?? false;
+  const excerptsYaml = ctx.excerptsYaml ?? true;
   const defaultIndentation = ctx.defaultIndentation ?? 0;
   let filePlasterTemplate: string | undefined;
   let fileReplacePipeline: ((code: string) => string) | null = null;

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -87,10 +87,7 @@ export interface MarkdownInjectContext {
   readFile: (relativePath: string, region?: string) => string | null;
   /** Initial `path-base` (directory prefix for excerpt sources). */
   pathBase?: string;
-  /**
-   * When `true`, applies language-specific plaster comment wrappers in YAML
-   * excerpt mode (default `true`).
-   */
+  /** Legacy option retained for compatibility; plaster handling is now YAML-style by default. */
   excerptsYaml?: boolean;
   /** Default extra spaces when `indent-by` is omitted on a fragment directive. */
   defaultIndentation?: number;
@@ -99,10 +96,7 @@ export interface MarkdownInjectContext {
    * file-level set `replace`, on the joined excerpt string.
    */
   globalReplace?: string;
-  /**
-   * Default plaster text when neither the PI nor a file-level `plaster` set
-   * instruction overrides it.
-   */
+  /** Default plaster template when neither the PI nor a file-level `plaster` set instruction overrides it. */
   globalPlasterTemplate?: string;
   /**
    * When `true` (default), escape Angular-style `{{` / `}}` in injected lines.
@@ -336,39 +330,40 @@ function formatPlasterWithDelims(
   return d.end ? `${d.start} ${text} ${d.end}` : `${d.start} ${text}`;
 }
 
-function plasterTextForLang(text: string, lang: string): string | null {
+function plasterTemplateForLang(text: string, lang: string): string | null {
   const d = PLASTER_COMMENT_DELIMS_BY_LANG.get(lang.toLowerCase());
   if (d === undefined) return null;
   return formatPlasterWithDelims(text, d);
 }
 
 /**
- * Plaster pass: `plaster="none"` removes default-plaster lines. In legacy mode,
- * explicit plaster text replaces the raw `DEFAULT_PLASTER` marker. In YAML
- * excerpt mode, plaster text is wrapped using the language-specific plaster
- * comment form.
+ * Plaster pass: `plaster="none"` removes plaster lines. Otherwise, explicit
+ * values are treated as full plaster templates and `$defaultPlaster` expands to
+ * the default plaster string. When no template is set, a language-specific
+ * default template is used when available; languages without a known comment
+ * syntax keep the raw plaster marker.
  */
 function applyPlasterToLines(
   lines: string[],
-  plasterText: string | undefined,
+  plasterTemplate: string | undefined,
   lang: string,
-  excerptsYaml: boolean,
 ): string[] {
-  if (plasterText === 'none') {
+  if (plasterTemplate === 'none') {
     return lines.filter((line) => !line.includes(DEFAULT_PLASTER));
   }
-  if (!excerptsYaml) {
-    if (plasterText === undefined) return lines;
-    return lines
-      .join('\n')
-      .split(DEFAULT_PLASTER)
-      .join(plasterText)
-      .split('\n');
+
+  const explicitTemplate =
+    plasterTemplate === undefined
+      ? undefined
+      : plasterTemplate.replaceAll('$defaultPlaster', DEFAULT_PLASTER);
+  const effectiveTemplate =
+    explicitTemplate ?? plasterTemplateForLang(DEFAULT_PLASTER, lang);
+  if (effectiveTemplate === null || effectiveTemplate === DEFAULT_PLASTER) {
+    return lines;
   }
-  const tpl = plasterTextForLang(plasterText ?? DEFAULT_PLASTER, lang);
-  if (tpl === null) return lines;
+
   const joined = lines.join('\n');
-  return joined.split(DEFAULT_PLASTER).join(tpl).split('\n');
+  return joined.split(DEFAULT_PLASTER).join(effectiveTemplate).split('\n');
 }
 
 function tryParseFragmentIndent(
@@ -428,7 +423,6 @@ export function injectMarkdown(
   const lines = markdown.split('\n');
   const out: string[] = [];
   let pathBase = ctx.pathBase ?? '';
-  const excerptsYaml = ctx.excerptsYaml ?? true;
   const defaultIndentation = ctx.defaultIndentation ?? 0;
   let filePlasterTemplate: string | undefined;
   let fileReplacePipeline: ((code: string) => string) | null = null;
@@ -490,7 +484,11 @@ export function injectMarkdown(
         return;
       }
       const val = entry.value ?? '';
-      filePlasterTemplate = val === 'unset' ? undefined : val;
+      if (val === 'unset') {
+        err('plaster: invalid setting value on set instruction');
+        return;
+      }
+      filePlasterTemplate = val;
       return;
     }
     if (entry.key === 'class') {
@@ -587,7 +585,7 @@ export function injectMarkdown(
     } else {
       plasterInput = filePlasterTemplate ?? ctx.globalPlasterTemplate;
     }
-    working = applyPlasterToLines(working, plasterInput, lang, excerptsYaml);
+    working = applyPlasterToLines(working, plasterInput, lang);
 
     working = applyOrderedExcerptTransformOps(
       working,

--- a/src/update.ts
+++ b/src/update.ts
@@ -30,7 +30,7 @@ export interface UpdateOptions {
   escapeNgInterpolation?: boolean;
   /** Global replace expression applied after per-instruction + file-level transforms. */
   globalReplace?: string;
-  /** Default plaster text when the PI / file-level set does not override it. */
+  /** Default plaster template when the PI / file-level set does not override it. */
   globalPlasterTemplate?: string;
   log?: (msg: string) => void;
 }

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -884,7 +884,7 @@ describe('inject', () => {
       `);
     });
 
-    it('uses empty fragment plaster text with the normal wrapper', () => {
+    it('uses an empty fragment plaster template', () => {
       const src = dedent`
         // #docregion
         before
@@ -910,14 +910,15 @@ describe('inject', () => {
 
         \`\`\`dart
         before
-        //
+
         after
         \`\`\`
 
       `);
     });
 
-    it('uses plaster="unset" on a set instruction to clear file-level plaster', () => {
+    it('errors on plaster="unset" on a set instruction', () => {
+      const onError = vi.fn();
       const src = dedent`
         // #docregion
         a
@@ -939,6 +940,7 @@ describe('inject', () => {
       const out = injectMarkdown(md, {
         readFile: (p) => (p === 'unset-plaster.dart' ? src : null),
         excerptsYaml: true,
+        onError,
       });
       expect(out).toStrictEqual(dedent`
         <?code-excerpt plaster="none"?>
@@ -947,11 +949,13 @@ describe('inject', () => {
 
         \`\`\`dart
         a
-        // ···
         b
         \`\`\`
 
       `);
+      expect(onError).toHaveBeenCalledWith(
+        'plaster: invalid setting value on set instruction',
+      );
     });
 
     it('leaves block unchanged on repeated plaster setting', () => {
@@ -1010,6 +1014,70 @@ describe('inject', () => {
       expect(onError).toHaveBeenCalledWith(
         'plaster: invalid setting value on fragment instruction',
       );
+    });
+
+    it('treats explicit fragment plaster as a full template', () => {
+      const src = dedent`
+        // #docregion
+        before
+        // #enddocregion
+        // #docregion
+        after
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "tpl.dart" plaster="/*...*/"?>
+
+        \`\`\`dart
+        .
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'tpl.dart' ? src : null),
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "tpl.dart" plaster="/*...*/"?>
+
+        \`\`\`dart
+        before
+        /*...*/
+        after
+        \`\`\`
+
+      `);
+    });
+
+    it('expands $defaultPlaster inside an explicit plaster template', () => {
+      const src = dedent`
+        // #docregion
+        before
+        // #enddocregion
+        // #docregion
+        after
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "tpl-default.dart" plaster="/* $defaultPlaster */"?>
+
+        \`\`\`dart
+        .
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'tpl-default.dart' ? src : null),
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "tpl-default.dart" plaster="/* $defaultPlaster */"?>
+
+        \`\`\`dart
+        before
+        /* ··· */
+        after
+        \`\`\`
+
+      `);
     });
 
     it.each([

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -103,7 +103,7 @@ So, this step now also includes correcting:
 > Note the spec may be in an inconsistent state wrt plaster processing. We're
 > accepting this as temporary, and will fix it in the next step.
 
-5. [ ] **Revisit plaster spec and processing**
+5. [x] **Revisit plaster spec and processing**
 
 Plaster spec, code, and tests cleanup.
 


### PR DESCRIPTION
- Summary
  - Simplifies plaster handling around a single YAML-style/default-template model.
  - Aligns the local spec, code, and tests on `plaster` as a full template value.
  - Keeps old updater bare-`plaster` parity deferred instead of mixing it into the current tool semantics.

- Changes
  - Updates `docs/spec.md` to remove the normative YAML/pre-YAML split.
  - Updates `docs/migration-notes.md` to distinguish `null` plaster-template fallback from `plaster=""`.
  - Changes `src/inject.ts` so plaster handling uses YAML-style default-template semantics by default.
  - Treats explicit `plaster` values as full templates and expands `$defaultPlaster`.
  - Keeps bare `plaster` invalid and treats `plaster="unset"` as unsupported.
  - Updates local plaster coverage in `test/inject.test.ts`.
  - Re-skips the two old updater plaster goldens in `test/updater-goldens.test.ts` because they still encode deferred legacy behavior.

- Testing
  - Runs `npm run test:base`.
  - Leaves the two plaster parity goldens skipped intentionally for later resolution.

- Follow-up
  - Removes the remaining internal YAML-mode split next.
  - Decides whether the deferred plaster goldens should be rewritten as repo-owned expectations or dropped.