### PR TITLE
Tighten PI arg syntax and simplify plaster semantics

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -53,7 +53,8 @@ Specifies a source file (and optionally a named region) to inject:
     directives).
   - **with** `#docregion` / `#enddocregion` directives resolve the
     [Default region](#default-region).
-- Additional named arguments follow as `key="value"` pairs.
+- Additional named arguments follow as `id="value"` pairs.
+- Named-argument values must be enclosed in double quotes.
 
 **Example:**
 
@@ -92,6 +93,9 @@ Fragment instructions may use the following named arguments (plus the positional
 path string). Set instructions accept **only** `path-base`, `replace`,
 `plaster`, or no-op compatibility keys `class` / `title`—see
 [Set instruction](#set-instruction); any other set key triggers a warning.
+
+All PI named arguments use the form `id="value"`. Valueless named arguments are
+not part of this tool's supported syntax.
 
 | Argument        | Scope | Kind  | Argument values              | Description                                                     |
 | --------------- | ----- | ----- | ---------------------------- | --------------------------------------------------------------- |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -137,7 +137,7 @@ fragment instructions in the same file. Precedence:
 
 - `indent-by`: overrides global settings
 - `path-base`: appends to the global base directory
-- `plaster`: overrides global settings; bare `plaster` is invalid
+- `plaster`: overrides global settings
 - `replace`: see [Replace order](#replace-order)
 
 ### Fragment instructions
@@ -157,7 +157,6 @@ Fragment-setting semantics:
 - `plaster=""` sets the plaster template to the empty string.
 - `plaster="none"` ensures that no plaster template is injected into the
   excerpt.
-- bare `plaster` is invalid in fragment scope.
 - `indent-by` is applied after the excerpt content has been fully transformed.
   Overrides file-level and global settings.
 - Repeating `indent-by` or `plaster` on the same fragment instruction is an

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -18,7 +18,7 @@ import {
  * {@link PROC_INSTR_RE}, triggers `onWarning`, and the line is skipped as an instruction.
  */
 const PROC_INSTR_BODY =
-  /^(?<linePrefix>\s*((?:\/\/\/?|-|\*)\s*)?)?<\?code-excerpt\s*(?:"(?<unnamed>[^"]+)")?(?<named>(?:\s+[-\w]+(?:\s*=\s*"[^"]*")?\s*)*)\??>/;
+  /^(?<linePrefix>\s*((?:\/\/\/?|-|\*)\s*)?)?<\?code-excerpt\s*(?:"(?<unnamed>[^"]+)")?(?<named>(?:\s+[-\w]+\s*=\s*"[^"]*"\s*)*)\??>/;
 
 /**
  * Strict match: the **entire line** is only a `<?code-excerpt ...?>` plus optional trailing
@@ -31,7 +31,7 @@ export const PROC_INSTR_RE = new RegExp(
   PROC_INSTR_BODY.flags,
 );
 
-const NAMED_ARG_RE = /^([-\w]+)\s*(=\s*"([^"]*)"\s*|\b)\s*/;
+const NAMED_ARG_RE = /^([-\w]+)\s*=\s*"([^"]*)"\s*/;
 
 const SET_KNOWN_KEYS = new Set([
   'path-base',
@@ -43,8 +43,7 @@ const SET_KNOWN_KEYS = new Set([
 
 export interface ParsedNamedArgEntry {
   key: string;
-  value: string | undefined;
-  hasValue: boolean;
+  value: string;
 }
 
 export interface ParsedNamedArgs {
@@ -147,21 +146,19 @@ function normalizeListLinePrefix(prefix: string): string {
 export function parseNamedArgs(
   named: string,
   onError?: (msg: string) => void,
-): ParsedNamedArgs {
+): ParsedNamedArgs | null {
   const entries: ParsedNamedArgEntry[] = [];
   let rest = named.trim();
   while (rest.length > 0) {
     const m = NAMED_ARG_RE.exec(rest);
     if (m === null) {
       onError?.(`instruction argument parsing failure at/around: ${rest}`);
-      break;
+      return null;
     }
     const key = m[1]!;
-    const eqOrBare = m[2] ?? '';
     entries.push({
       key,
-      value: m[3] ?? undefined,
-      hasValue: eqOrBare.trimStart().startsWith('='),
+      value: m[2] ?? '',
     });
     rest = rest.slice(m[0].length);
   }
@@ -175,7 +172,6 @@ export interface ParsedFragmentArgs {
   regionValue: string | undefined;
   indentByRaw: string | undefined;
   plasterTemplate: string | undefined;
-  hasBarePlaster: boolean;
   hasUnsupportedDiff: boolean;
 }
 
@@ -187,7 +183,6 @@ export function parseFragmentArgs(
   let regionValue: string | undefined;
   let indentByRaw: string | undefined;
   let plasterTemplate: string | undefined;
-  let hasBarePlaster = false;
   let hasUnsupportedDiff = false;
   const seenSettings = new Set<FragmentSettingName>();
 
@@ -205,34 +200,29 @@ export function parseFragmentArgs(
       case 'remove':
       case 'retain':
       case 'replace':
-        if (!entry.hasValue) continue;
         transformOps.push({
           name: entry.key,
-          value: entry.value ?? '',
+          value: entry.value,
         });
         break;
       case 'region':
         if (seenSettings.has('region')) return rejectRepeatedSetting('region');
         seenSettings.add('region');
-        regionValue = entry.hasValue ? (entry.value ?? '') : undefined;
+        regionValue = entry.value;
         break;
       case 'indent-by':
         if (seenSettings.has('indent-by')) {
           return rejectRepeatedSetting('indent-by');
         }
         seenSettings.add('indent-by');
-        indentByRaw = entry.hasValue ? (entry.value ?? '') : undefined;
+        indentByRaw = entry.value;
         break;
       case 'plaster':
         if (seenSettings.has('plaster')) {
           return rejectRepeatedSetting('plaster');
         }
         seenSettings.add('plaster');
-        if (entry.hasValue) {
-          plasterTemplate = entry.value ?? '';
-        } else {
-          hasBarePlaster = true;
-        }
+        plasterTemplate = entry.value;
         break;
       case 'diff-with':
       case 'diff-u':
@@ -248,7 +238,6 @@ export function parseFragmentArgs(
     regionValue,
     indentByRaw,
     plasterTemplate,
-    hasBarePlaster,
     hasUnsupportedDiff,
   };
 }
@@ -457,19 +446,11 @@ export function injectMarkdown(
     }
     const entry = pn.entries[0]!;
     if (entry.key === 'path-base') {
-      if (!entry.hasValue) {
-        err('path-base: invalid setting value on set instruction');
-        return;
-      }
-      pathBase = entry.hasValue ? (entry.value ?? '') : '';
+      pathBase = entry.value;
       return;
     }
     if (entry.key === 'replace') {
-      if (!entry.hasValue) {
-        err('replace: invalid setting value on set instruction');
-        return;
-      }
-      const val = entry.hasValue ? (entry.value ?? '') : '';
+      const val = entry.value;
       if (val === '') {
         fileReplacePipeline = null;
       } else {
@@ -479,11 +460,7 @@ export function injectMarkdown(
       return;
     }
     if (entry.key === 'plaster') {
-      if (!entry.hasValue) {
-        err('plaster: invalid setting value on set instruction');
-        return;
-      }
-      const val = entry.value ?? '';
+      const val = entry.value;
       if (val === 'unset') {
         err('plaster: invalid setting value on set instruction');
         return;
@@ -512,6 +489,14 @@ export function injectMarkdown(
     linePrefixRaw: string | undefined,
   ): string[] => {
     const namedArgs = parseNamedArgs(namedStr, err);
+    if (namedArgs === null) {
+      const fb = consumeFenceBlock(queue);
+      if (fb.lines.length === 0) {
+        err(`reached end of input, expect code block - "${unnamed}"`);
+        return [];
+      }
+      return fb.lines;
+    }
     const fragmentArgs = parseFragmentArgs(namedArgs, err);
     const parsed = parsePathAndRegion(unnamed);
     let region = parsed.region;
@@ -574,10 +559,7 @@ export function injectMarkdown(
     const lang = codeLang(opening, relPath);
 
     let plasterInput: string | undefined;
-    if (fragmentArgs.hasBarePlaster) {
-      err('plaster: invalid setting value on fragment instruction');
-      return [opening, ...oldInner, closing];
-    } else if (fragmentArgs.plasterTemplate === 'unset') {
+    if (fragmentArgs.plasterTemplate === 'unset') {
       err('plaster: invalid setting value on fragment instruction');
       return [opening, ...oldInner, closing];
     } else if (fragmentArgs.plasterTemplate !== undefined) {
@@ -660,7 +642,9 @@ export function injectMarkdown(
     }
 
     if (unnamed === undefined) {
-      handleSetInstruction(parseNamedArgs(namedStr, err));
+      const namedArgs = parseNamedArgs(namedStr, err);
+      if (namedArgs === null) continue;
+      handleSetInstruction(namedArgs);
       continue;
     }
 

--- a/test/README.md
+++ b/test/README.md
@@ -50,7 +50,7 @@ Together, every fragment argument below is exercised somewhere.
 
 [^4]: Set-level `replace` only
 
-[^5]: `excerptsYaml`
+[^5]: Default plaster-template behavior and local plaster-setting cases
 
 `inject.test.ts` does not re-test every transform keyword; goldens and
 `transform.test.ts` cover those paths end-to-end or in isolation.

--- a/test/fixtures/code-excerpt-updater/README.md
+++ b/test/fixtures/code-excerpt-updater/README.md
@@ -5,6 +5,10 @@ This directory vendors `test_data/` from
 (MIT license) so Vitest can assert byte-for-byte parity with the Dart updater’s
 expected outputs under `test_data/expected/`.
 
+Repo-owned divergence goldens live under `test_data/expected-local/`. The test
+harness prefers those files over vendored `test_data/expected/` for the same
+relative path.
+
 ## Generated output (`generated/`)
 
 The **`generated/`** directory is **committed** (with `.gitkeep` and a local

--- a/test/fixtures/code-excerpt-updater/test_data/expected-local/plaster-global-option.md
+++ b/test/fixtures/code-excerpt-updater/test_data/expected-local/plaster-global-option.md
@@ -1,0 +1,48 @@
+## Test plaster feature
+
+### Globally set default plaster
+
+<?code-excerpt "plaster.dart"?>
+```
+var greeting = 'hello';
+// Insert your code here ···
+var scope = 'world';
+```
+
+### Remove plaster
+
+<?code-excerpt plaster="none"?>
+
+<?code-excerpt "plaster.txt"?>
+```
+abc
+def
+```
+
+<?code-excerpt "plaster.txt" plaster?>
+```
+```
+
+<?code-excerpt plaster?>
+
+<?code-excerpt "plaster.txt"?>
+```
+abc
+def
+```
+
+### Custom template
+
+<?code-excerpt "plaster.dart" plaster="/*...*/"?>
+```
+var greeting = 'hello';
+/*...*/
+var scope = 'world';
+```
+
+<?code-excerpt "plaster.dart" plaster="/* $defaultPlaster */"?>
+```
+var greeting = 'hello';
+/* ··· */
+var scope = 'world';
+```

--- a/test/inject-args.test.ts
+++ b/test/inject-args.test.ts
@@ -8,16 +8,13 @@ import { dedent } from './helpers/dedent.js';
 
 describe('inject arg processing', () => {
   describe('parseNamedArgs', () => {
-    it('preserves encounter order and distinguishes bare vs valued args', () => {
-      const parsed = parseNamedArgs(
-        'skip="1" plaster retain="x" replace="/a/b/g"',
-      );
+    it('preserves encounter order for named args', () => {
+      const parsed = parseNamedArgs('skip="1" retain="x" replace="/a/b/g"');
 
       expect(parsed.entries).toStrictEqual([
-        { key: 'skip', value: '1', hasValue: true },
-        { key: 'plaster', value: undefined, hasValue: false },
-        { key: 'retain', value: 'x', hasValue: true },
-        { key: 'replace', value: '/a/b/g', hasValue: true },
+        { key: 'skip', value: '1' },
+        { key: 'retain', value: 'x' },
+        { key: 'replace', value: '/a/b/g' },
       ]);
     });
 
@@ -25,9 +22,17 @@ describe('inject arg processing', () => {
       const onError = vi.fn();
       const parsed = parseNamedArgs('skip="1" @oops replace="/a/b/g"', onError);
 
-      expect(parsed.entries).toStrictEqual([
-        { key: 'skip', value: '1', hasValue: true },
-      ]);
+      expect(parsed).toBeNull();
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('instruction argument parsing failure'),
+      );
+    });
+
+    it('rejects valueless named args', () => {
+      const onError = vi.fn();
+      const parsed = parseNamedArgs('skip="1" plaster retain="x"', onError);
+
+      expect(parsed).toBeNull();
       expect(onError).toHaveBeenCalledWith(
         expect.stringContaining('instruction argument parsing failure'),
       );
@@ -51,7 +56,6 @@ describe('inject arg processing', () => {
         regionValue: 'r',
         indentByRaw: '2',
         plasterTemplate: 'tpl',
-        hasBarePlaster: false,
         hasUnsupportedDiff: false,
       });
     });

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -390,6 +390,26 @@ describe('inject', () => {
       );
     });
 
+    it('treats valueless named args as invalid processing-instruction syntax', () => {
+      const onError = vi.fn();
+      const md = dedent`
+        <?code-excerpt "basic.dart (greeting)" title?>
+
+        \`\`\`dart
+        keep
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: () => '//\n',
+        onError,
+      });
+      expect(out).toStrictEqual(md);
+      expect(onError).toHaveBeenCalledWith(
+        expect.stringContaining('invalid processing instruction'),
+      );
+    });
+
     it('warns when text follows ?> on the same line and does not inject', () => {
       const onWarning = vi.fn();
       const onError = vi.fn();

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -527,40 +527,6 @@ describe('inject', () => {
       );
     });
 
-    it('errors on bare set plaster and leaves later fragments unchanged', () => {
-      const onError = vi.fn();
-      const src = dedent`
-        // #docregion
-        SRC_TOKEN
-        // #enddocregion
-      `;
-      const md = dedent`
-        <?code-excerpt plaster?>
-        <?code-excerpt "set-bare-plaster.dart"?>
-
-        \`\`\`
-        ORIGINAL
-        \`\`\`
-
-      `;
-      const out = injectMarkdown(md, {
-        readFile: (p) => (p === 'set-bare-plaster.dart' ? src : null),
-        onError,
-      });
-      expect(out).toStrictEqual(dedent`
-        <?code-excerpt plaster?>
-        <?code-excerpt "set-bare-plaster.dart"?>
-
-        \`\`\`
-        SRC_TOKEN
-        \`\`\`
-
-      `);
-      expect(onError).toHaveBeenCalledWith(
-        'plaster: invalid setting value on set instruction',
-      );
-    });
-
     it('clears file-level replace when set replace is empty', () => {
       const src = dedent`
         // #docregion
@@ -851,7 +817,7 @@ describe('inject', () => {
       );
     });
 
-    it('substitutes plaster markers when excerptsYaml is true', () => {
+    it('substitutes plaster markers using the default plaster template', () => {
       const src = dedent`
         // #docregion
         before
@@ -870,7 +836,6 @@ describe('inject', () => {
       `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === 'pl.dart' ? src : null),
-        excerptsYaml: true,
       });
       expect(out).toStrictEqual(dedent`
         <?code-excerpt "pl.dart"?>
@@ -903,7 +868,6 @@ describe('inject', () => {
       `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === 'empty-plaster.dart' ? src : null),
-        excerptsYaml: true,
       });
       expect(out).toStrictEqual(dedent`
         <?code-excerpt "empty-plaster.dart" plaster=""?>
@@ -939,7 +903,6 @@ describe('inject', () => {
       `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === 'unset-plaster.dart' ? src : null),
-        excerptsYaml: true,
         onError,
       });
       expect(out).toStrictEqual(dedent`
@@ -978,7 +941,6 @@ describe('inject', () => {
       `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === 'dup-plaster.dart' ? src : null),
-        excerptsYaml: true,
         onError,
       });
       expect(out).toStrictEqual(md);
@@ -1007,7 +969,6 @@ describe('inject', () => {
       `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === 'frag-unset.dart' ? src : null),
-        excerptsYaml: true,
         onError,
       });
       expect(out).toStrictEqual(md);
@@ -1100,7 +1061,7 @@ describe('inject', () => {
       'php',
       'swift',
     ] as const)(
-      'substitutes plaster for excerptsYaml with %s fence',
+      'substitutes plaster with the default template for %s fence',
       (lang) => {
         const src = dedent`
           // #docregion
@@ -1119,7 +1080,6 @@ describe('inject', () => {
         `;
         const out = injectMarkdown(md, {
           readFile: (p) => (p === 'snippet.txt' ? src : null),
-          excerptsYaml: true,
         });
         const plasterLine = PLASTER_LINE_BY_FENCE_LANG[lang];
         expect(plasterLine).toBeDefined();
@@ -1135,7 +1095,7 @@ describe('inject', () => {
       },
     );
 
-    it('strips DEFAULT_PLASTER lines when plaster=none with excerptsYaml', () => {
+    it('strips DEFAULT_PLASTER lines when plaster=none', () => {
       const src = dedent`
         // #docregion
         a
@@ -1155,7 +1115,6 @@ describe('inject', () => {
       `;
       const out = injectMarkdown(md, {
         readFile: (p) => (p === 'pn.dart' ? src : null),
-        excerptsYaml: true,
       });
       expect(out).toStrictEqual(dedent`
         <?code-excerpt plaster="none"?>

--- a/test/updater-goldens.test.ts
+++ b/test/updater-goldens.test.ts
@@ -15,6 +15,7 @@ import { createDartUpdaterReadFile } from './helpers/dartUpdaterReadFile.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = join(__dirname, 'fixtures/code-excerpt-updater');
 const TEST_DATA = join(FIXTURE_ROOT, 'test_data');
+const EXPECTED_LOCAL = join(TEST_DATA, 'expected-local');
 /** Last-run inject output; diff against `test_data/expected/` (same relative path). */
 const GENERATED = join(FIXTURE_ROOT, 'generated');
 
@@ -35,6 +36,10 @@ function readSrc(rel: string): string {
 }
 
 function readExpected(rel: string): string {
+  const localPath = join(EXPECTED_LOCAL, rel);
+  if (existsSync(localPath)) {
+    return readFileSync(localPath, 'utf8');
+  }
   const expPath = join(TEST_DATA, 'expected', rel);
   if (existsSync(expPath)) {
     return readFileSync(expPath, 'utf8');
@@ -96,7 +101,6 @@ describe('code_excerpt_updater goldens', () => {
 
   const codeUpdates = [
     'basic_no_region.dart',
-    'basic_with_empty_region.md',
     'basic_with_region.dart',
     'escape_ng_interpolation.md',
     'fragment-indentation.md',
@@ -110,6 +114,10 @@ describe('code_excerpt_updater goldens', () => {
 
   it.each(codeUpdates)('code updates: %s', (rel) => {
     assertGolden(rel, defaultCtx);
+  });
+
+  it.skip('code updates: basic_with_empty_region.md (legacy valueless title syntax no longer supported)', () => {
+    assertGolden('basic_with_empty_region.md', defaultCtx);
   });
 
   it.skip('code updates: arg-order.md', () => {
@@ -166,11 +174,11 @@ describe('code_excerpt_updater goldens', () => {
     assertGolden('excerpt_yaml.md', excerptYamlCtx);
   });
 
-  it.skip('excerpt yaml defaults: plaster.md', () => {
+  it('excerpt yaml defaults: plaster.md', () => {
     assertGolden('plaster.md', excerptYamlCtx);
   });
 
-  it.skip('plaster-global-option.md', () => {
+  it.skip('plaster-global-option.md (legacy bare-plaster syntax no longer supported)', () => {
     assertGolden('plaster-global-option.md', {
       ...excerptYamlCtx,
       globalPlasterTemplate: '// Insert your code here $defaultPlaster',


### PR DESCRIPTION
- Summary
  - Tightens PI named-argument syntax to explicit `id="value"` form.
  - Simplifies plaster handling around the current single-template model.
  - Cleans up local tests and skips legacy fixture cases that still depend on unsupported valueless syntax.

- Changes
  - Updates `docs/spec.md` to require double-quoted named PI arg values and to drop valueless named args from supported syntax.
  - Tightens `src/inject.ts` so malformed or valueless named args invalidate the PI instead of being partially parsed.
  - Removes the old bare-arg plumbing from named-arg parsing and fragment arg classification.
  - Keeps plaster handling on the single YAML-style/default-template path and treats explicit `plaster` values as full templates.
  - Updates `test/inject-args.test.ts` and `test/inject.test.ts` for the stricter parser and current plaster model.
  - Cleans up authored docs/tests so they no longer mention bare `plaster`.
  - Replaces the old plaster golden override mechanism with a repo-owned `expected-local/` path, then re-skips the remaining legacy bare-`plaster` fixture with an explicit reason.
  - Skips `basic_with_empty_region.md` with an explicit reason because it still depends on legacy valueless `title` syntax.

- Testing
  - Runs `npm run test:base`.
  - Current result: `228 passed, 7 skipped`.

- Follow-up
  - Reorganizes fixture-based updater tests into normalized case directories.
  - Replaces remaining legacy vendored cases with current-syntax repo-owned cases.