### PR TITLE
Tighten inject behavior and add site-www coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 - [Markdown input assumptions](docs/spec.md#markdown-input-assumptions).
 - Plaster templates for common fenced-code language identifiers, including
   `javascript`, `typescript`, `csharp`, `cs`, and more.
+- Reusable `test:site-www` integration harness for exercising the updater
+  against a local `site-www` clone.
 - **Tilde (`~~~`) code fences** in markdown: recognized as opening/closing
   fences and paired by fence **kind** (backtick vs tilde vs Liquid prettify),
   consistent with backtick and prettify blocks.
@@ -36,6 +38,11 @@ The format is based on [Keep a Changelog][], and this project adheres to
 - Built-in `.excerpt.yaml` sidecar reading now treats a present sidecar as
   authoritative: missing sidecar regions report an error instead of falling back
   to plain-source extraction.
+- PI parsing now tolerates whitespace before `?>`, warns on malformed
+  `<? code-excerpt ...?>` openers, and accepts backtick / tilde fence runs
+  longer than 3.
+- Discontiguous-region plaster lines now inherit the reopening `#docregion`
+  directive indentation, matching `site-shared` and `site-www`.
 
 ## [v0.1.0][] - 2026-04-13
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -68,9 +68,8 @@ Directory walking, file updating, CLI entry point.
 - [x] Add built-in `.excerpt.yaml` sidecar support in the disk updater path,
       including authoritative-sidecar semantics and explicit sidecar error
       reporting.
-- [x] Add normalized repo-owned updater fixtures under
-      `test/fixtures/updater/` plus the `test/updater-fixtures.test.ts`
-      filesystem harness.
+- [x] Add normalized repo-owned updater fixtures under `test/fixtures/updater/`
+      plus the `test/updater-fixtures.test.ts` filesystem harness.
 
 ## Phase 5a - follow-ups
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -19,6 +19,9 @@ file, region, and transforms to apply to the code excerpt, allowing for
 `code-excerpter` to refresh code blocks when their originating source code
 changes.
 
+Per XML PI syntax, there is no space between `<?` and `code-excerpt`.
+`<? code-excerpt ...?>` is treated as malformed and ignored with a warning.
+
 ## Markdown input assumptions
 
 The `code-excerpter` tool is a simple line-oriented scanner, not a full Markdown
@@ -69,9 +72,12 @@ Specifies a source file (and optionally a named region) to inject:
 Supported fences are:
 
 - Markdown code-block fences using either syntax:
-  - backtick fences (` ``` ` ... ` ``` `) or
-  - tilde fences (`~~~` … `~~~`)
+  - backtick fences (runs of 3 or more backticks), or
+  - tilde fences (runs of 3 or more tildes)
 - Hugo/Liquid `{% prettify … %}` ... `{% endprettify %}` pairs.
+
+For backtick and tilde fences, the closing fence must be the same kind and at
+least as long as the opening fence.
 
 ### Set instruction
 
@@ -230,9 +236,10 @@ margin token prefix:
 
 ## Optional trailing whitespace for instruction lines
 
-Any whitespace following the closing `?>` is ignored. Any non-whitespace after
-the closing `?>` is reported via a warning and the document is left unchanged
-for that line.
+Any whitespace between the final attribute and the closing `?>` is ignored, as
+is any whitespace following the closing `?>`. Any non-whitespace after the
+closing `?>` is reported via a warning and the document is left unchanged for
+that line.
 
 ---
 
@@ -326,6 +333,9 @@ The `plaster` argument sets the full plaster template, not just the plaster
 string. For example, `plaster="/* $defaultPlaster */"` uses that whole template,
 while `plaster="none"` removes plaster injection. The `$defaultPlaster`
 placeholder expands to the default plaster string `···`.
+
+For discontiguous regions, the plaster line inherits the indentation of the
+reopening `#docregion` directive.
 
 ## Acknowledgments
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -169,6 +169,9 @@ below states what it does / its purpose, not how it achieves that (see
   order, stop on the first failure” instead of long `&&` chains. Uses **bash**;
   on Windows, Git Bash, WSL, or another environment where `bash` is on `PATH` is
   required.
+- `test:site-www`: Runs the reusable `site-www` integration harness from
+  `scripts/test-site-www.mts`. Supports `--root <dir>`, optional target files,
+  and `--write` for restoring excerpted docs in a local `site-www` clone.
 - `postbuild`: Asserts `dist/` contains the expected build artifacts.
 - `prepare`: Builds on install so git URL consumers get `dist/`.
 - `test`: Offers the default “trust this tree” path: full read-only gates, then

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pretest:watch": "npm run build",
     "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "test:base": "KEEP_TEST_TMP=${KEEP_TEST_TMP:-0} vitest run",
+    "test:site-www": "tsx scripts/test-site-www.mts",
     "test:watch": "vitest",
     "test": "npm run check && npm run test:base",
     "update:packages": "npm-check-updates -u"

--- a/scripts/test-site-www.mts
+++ b/scripts/test-site-www.mts
@@ -1,0 +1,310 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import {
+  formatExcerptYamlReadError,
+  tryReadExcerptYamlSidecar,
+} from '../src/helpers/excerptYaml.ts';
+import {
+  injectMarkdown,
+  PROC_INSTR_RE,
+  type MarkdownInjectContext,
+} from '../src/index.ts';
+
+const DEFAULT_WORKTREE = resolve('tmp/site-www-phase6');
+
+const CODE_BLOCK_START =
+  /^\s*(?:\/\/\/?)?\s*(?<token>`{3,}|~{3,}|{%-?\s*prettify(\s+.*)?-?%})/;
+const CODE_BLOCK_END =
+  /^\s*(?:\/\/\/?)?\s*(?<token>`{3,}|~{3,}|{%-?\s*endprettify\s*-?%})/;
+
+const defaultSourceTransforms: Array<(text: string) => string> = [
+  (text) => text.replaceAll('//!<br>', ''),
+  (text) => text.replaceAll(/ellipsis(<\w+>)?(\(\))?;?/g, '...'),
+  (text) => text.replaceAll(/\/\*(\s*\.\.\.\s*)\*\//g, '$1'),
+  // Mirrors the upstream workaround that trims trailing blank lines after
+  // formatter-introduced block-close whitespace.
+  (text) => text.replaceAll(/[\r\n]+$/g, ''),
+];
+
+interface RunResult {
+  filesProcessed: number;
+  filesNeedingUpdate: number;
+  errors: string[];
+  warnings: string[];
+}
+
+interface CliOptions {
+  docsRoot: string;
+  examplesRoot: string;
+  write: boolean;
+  targets: string[];
+  worktree: string;
+}
+
+function applyDefaultSourceTransforms(text: string): string {
+  return defaultSourceTransforms.reduce(
+    (working, transform) => transform(working),
+    text,
+  );
+}
+
+function fenceKind(token: string): 'backtick' | 'tilde' | 'prettify' {
+  if (token.startsWith('`')) return 'backtick';
+  if (token.startsWith('~')) return 'tilde';
+  return 'prettify';
+}
+
+function isMatchingFence(openingToken: string, closingToken: string): boolean {
+  const openKind = fenceKind(openingToken);
+  if (fenceKind(closingToken) !== openKind) return false;
+  if (openKind === 'prettify') return true;
+  return closingToken.length >= openingToken.length;
+}
+
+function consumeFenceBlock(queue: string[]): {
+  closed: boolean;
+  lines: string[];
+} {
+  if (queue.length === 0) return { closed: false, lines: [] };
+  const opening = queue.shift()!;
+  const openingToken = CODE_BLOCK_START.exec(opening)?.groups?.token;
+  if (openingToken === undefined) return { closed: false, lines: [opening] };
+
+  const inner: string[] = [];
+  while (queue.length > 0) {
+    const line = queue[0]!;
+    const closingToken = CODE_BLOCK_END.exec(line)?.groups?.token;
+    if (
+      closingToken !== undefined &&
+      isMatchingFence(openingToken, closingToken)
+    ) {
+      queue.shift();
+      return { closed: true, lines: [opening, ...inner, line] };
+    }
+    inner.push(queue.shift()!);
+  }
+
+  return { closed: false, lines: [opening, ...inner] };
+}
+
+function applyDefaultTransformsToExcerptBlocks(markdown: string): string {
+  const queue = markdown.split('\n');
+  const out: string[] = [];
+
+  while (queue.length > 0) {
+    const line = queue.shift()!;
+    out.push(line);
+    if (!PROC_INSTR_RE.test(line)) continue;
+
+    while (queue.length > 0 && /^\s*$/.test(queue[0]!)) {
+      out.push(queue.shift()!);
+    }
+
+    const block = consumeFenceBlock(queue);
+    if (block.lines.length === 0) continue;
+    if (!block.closed) {
+      out.push(...block.lines);
+      continue;
+    }
+
+    const [opening, ...mid] = block.lines;
+    const closing = mid.pop()!;
+    const transformedInner = applyDefaultSourceTransforms(mid.join('\n')).split(
+      '\n',
+    );
+    out.push(opening, ...transformedInner, closing);
+  }
+
+  return out.join('\n');
+}
+
+function normalizeForCompare(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n');
+}
+
+function trailingNewlineCount(text: string): number {
+  let count = 0;
+  for (let i = text.length - 1; i >= 0 && text[i] === '\n'; i--) {
+    count++;
+  }
+  return count;
+}
+
+function normalizeForWrite(text: string, original: string): string {
+  const trimmed = normalizeForCompare(text).replace(/\n+$/g, '');
+  return `${trimmed}${'\n'.repeat(trailingNewlineCount(original))}`;
+}
+
+function excerptYamlErrorKey(resolvedPath: string, region = ''): string {
+  return `${resolvedPath}\0${region}`;
+}
+
+function createReadAccessors(
+  srcRoot: string,
+): Pick<MarkdownInjectContext, 'readFile' | 'readError'> {
+  let lastReadError: { key: string; message: string } | null = null;
+
+  return {
+    readFile: (resolvedPath: string, region = ''): string | null => {
+      const key = excerptYamlErrorKey(resolvedPath, region);
+      if (lastReadError?.key === key) {
+        lastReadError = null;
+      }
+
+      try {
+        const sidecar = tryReadExcerptYamlSidecar(
+          srcRoot,
+          resolvedPath,
+          region,
+        );
+        if (sidecar.status === 'found') {
+          return applyDefaultSourceTransforms(sidecar.excerpt);
+        }
+        if (sidecar.status === 'file-not-found') {
+          return applyDefaultSourceTransforms(
+            readFileSync(resolve(srcRoot, resolvedPath), 'utf8'),
+          );
+        }
+
+        lastReadError = {
+          key,
+          message: formatExcerptYamlReadError(
+            resolvedPath,
+            region,
+            sidecar.status,
+          ),
+        };
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    readError: (resolvedPath: string, region = ''): string | null =>
+      lastReadError?.key === excerptYamlErrorKey(resolvedPath, region)
+        ? lastReadError.message
+        : null,
+  };
+}
+
+async function collectMarkdownFiles(root: string): Promise<string[]> {
+  const info = await stat(root);
+  if (!info.isDirectory()) return [];
+
+  const result: string[] = [];
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...(await collectMarkdownFiles(full)));
+      continue;
+    }
+    if (entry.isFile() && full.endsWith('.md')) {
+      result.push(full);
+    }
+  }
+  return result;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let worktree = DEFAULT_WORKTREE;
+  const passthrough: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === '--root') {
+      const next = argv[++i];
+      if (next === undefined) {
+        throw new Error('missing value for --root');
+      }
+      worktree = resolve(next);
+      continue;
+    }
+    passthrough.push(arg);
+  }
+
+  const write = passthrough.includes('--write');
+  const targets = passthrough.filter((arg) => arg !== '--write');
+  return {
+    docsRoot: join(worktree, 'src', 'content'),
+    examplesRoot: join(worktree, 'examples'),
+    write,
+    targets,
+    worktree,
+  };
+}
+
+function resolveTargets(targets: string[], docsRoot: string): string[] {
+  return targets.map((target) =>
+    resolve(target.startsWith(docsRoot) ? target : join(docsRoot, target)),
+  );
+}
+
+async function run(options: CliOptions): Promise<RunResult> {
+  if (!existsSync(options.worktree)) {
+    throw new Error(`missing worktree: ${options.worktree}`);
+  }
+
+  const files =
+    options.targets.length === 0
+      ? (await collectMarkdownFiles(options.docsRoot)).sort()
+      : resolveTargets(options.targets, options.docsRoot).sort();
+
+  const result: RunResult = {
+    filesProcessed: 0,
+    filesNeedingUpdate: 0,
+    errors: [],
+    warnings: [],
+  };
+
+  for (const filePath of files) {
+    const readAccessors = createReadAccessors(options.examplesRoot);
+    const ctx: MarkdownInjectContext = {
+      ...readAccessors,
+      instructionStats: { set: 0, fragment: 0 },
+      onWarning: (msg) =>
+        result.warnings.push(`${relative(options.worktree, filePath)}: ${msg}`),
+      onError: (msg) =>
+        result.errors.push(`${relative(options.worktree, filePath)}: ${msg}`),
+    };
+
+    result.filesProcessed++;
+    const original = await readFile(filePath, 'utf8');
+    const updated = applyDefaultTransformsToExcerptBlocks(
+      injectMarkdown(original, ctx),
+    );
+    if (normalizeForCompare(updated) !== normalizeForCompare(original)) {
+      result.filesNeedingUpdate++;
+      console.log(`needs update: ${relative(options.worktree, filePath)}`);
+      if (options.write) {
+        await writeFile(filePath, normalizeForWrite(updated, original), 'utf8');
+      }
+    }
+  }
+
+  return result;
+}
+
+const result = await run(parseArgs(process.argv.slice(2)));
+console.log(
+  [
+    `${result.filesProcessed} file(s) processed`,
+    `${result.filesNeedingUpdate} need update`,
+    `${result.errors.length} error(s)`,
+    `${result.warnings.length} warning(s)`,
+  ].join(', '),
+);
+
+if (result.errors.length > 0) {
+  for (const err of result.errors) console.error(`error: ${err}`);
+}
+if (result.warnings.length > 0) {
+  for (const warning of result.warnings) console.error(`warning: ${warning}`);
+}
+
+if (result.errors.length > 0 || result.filesNeedingUpdate > 0) {
+  process.exitCode = 1;
+}

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -113,6 +113,9 @@ export function extractExcerpts(
     if (regionNames.length === 0) regionNames.push(defaultRegionKey);
 
     for (const name of regionNames) {
+      if (excerpts.has(name) && !openExcerpts.has(name)) {
+        excerpts.get(name)?.push(directive.indentation + DEFAULT_PLASTER);
+      }
       const isNew = excerptStart(name);
       if (!isNew) {
         regionAlreadyStarted.push(quoteName(name));
@@ -141,7 +144,6 @@ export function extractExcerpts(
           // "empty region \"a\"". This matches the Dart excerpter exactly.
           warnRegions([name], (r) => `empty ${r}`);
         }
-        excerpt.push(directive.indentation + DEFAULT_PLASTER);
       } else {
         regionsWithoutStart.push(quoteName(name));
       }

--- a/src/helpers/re.ts
+++ b/src/helpers/re.ts
@@ -1,0 +1,10 @@
+export function re(
+  strings: TemplateStringsArray,
+  ...parts: Array<string | RegExp>
+): RegExp {
+  const source = String.raw(
+    strings,
+    ...parts.map((part) => (part instanceof RegExp ? part.source : part)),
+  );
+  return new RegExp(source);
+}

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -3,6 +3,7 @@ import {
   dropLeadingBlankLines,
   dropTrailingBlankLines,
   getExcerptRegionLines,
+  maxUnindent,
 } from './extract.js';
 import type { InstructionStats } from './instructionStats.js';
 import {
@@ -10,6 +11,7 @@ import {
   type ExcerptTransformOp,
   parseReplacePipeline,
 } from './transform.js';
+import { re } from './helpers/re.js';
 
 /**
  * Core `<?code-excerpt ...?>` match from the start of a line (no end-of-line rule).
@@ -18,7 +20,9 @@ import {
  * {@link PROC_INSTR_RE}, triggers `onWarning`, and the line is skipped as an instruction.
  */
 const PROC_INSTR_BODY =
-  /^(?<linePrefix>\s*((?:\/\/\/?|-|\*)\s*)?)?<\?code-excerpt\s*(?:"(?<unnamed>[^"]+)")?(?<named>(?:\s+[-\w]+\s*=\s*"[^"]*"\s*)*)\??>/;
+  /^(?<linePrefix>\s*((?:\/\/\/?|-|\*)\s*)?)?<\?code-excerpt\s*(?:"(?<unnamed>[^"]+)")?(?<named>(?:\s+[-\w]+\s*=\s*"[^"]*"\s*)*)\s*\??>/;
+
+const MALFORMED_PI_SPACE_AFTER_XML_OPEN = re`^(?:\s*((?:///?|-|\*)\s*)?)?<\?\s+code-excerpt\b`;
 
 /**
  * Strict match: the **entire line** is only a `<?code-excerpt ...?>` plus optional trailing
@@ -50,14 +54,13 @@ export interface ParsedNamedArgs {
   entries: ParsedNamedArgEntry[];
 }
 
-// TODO: bring in x`` string template / regex helper
-
 /** Backtick fences, tilde fences, or Liquid `{% prettify ... %}` (not arbitrary `{% ... %}`). */
 const CODE_BLOCK_START =
-  /^\s*(?:\/\/\/?)?\s*(```|~~~|{%-?\s*prettify(\s+.*)?-?%})/;
+  /^\s*(?:\/\/\/?)?\s*(?<token>`{3,}|~{3,}|{%-?\s*prettify(\s+.*)?-?%})/;
 
 /** Matches any code-block closing fence (backtick, tilde, or prettify). */
-const CODE_BLOCK_END = /^\s*(?:\/\/\/?)?\s*(```|~~~|{%-?\s*endprettify\s*-?%})/;
+const CODE_BLOCK_END =
+  /^\s*(?:\/\/\/?)?\s*(?<token>`{3,}|~{3,}|{%-?\s*endprettify\s*-?%})/;
 
 type FenceKind = 'backtick' | 'tilde' | 'prettify';
 
@@ -66,6 +69,16 @@ function fenceKind(token: string): FenceKind {
   if (token.startsWith('`')) return 'backtick';
   if (token.startsWith('~')) return 'tilde';
   return 'prettify';
+}
+
+function isMatchingFence(
+  openingToken: string,
+  closingToken: string,
+  openKind: FenceKind,
+): boolean {
+  if (fenceKind(closingToken) !== openKind) return false;
+  if (openKind === 'prettify') return true;
+  return closingToken.length >= openingToken.length;
 }
 
 const REGION_IN_PATH = /\s*\((.+)\)\s*$/;
@@ -356,8 +369,11 @@ function applyPlasterToLines(
     return lines;
   }
 
-  const joined = lines.join('\n');
-  return joined.split(DEFAULT_PLASTER).join(effectiveTemplate).split('\n');
+  return lines.map((line) => {
+    const leadingWhitespace = /^([ \t]*)/.exec(line)?.[1] ?? '';
+    if (line.trim() !== DEFAULT_PLASTER) return line;
+    return `${leadingWhitespace}${effectiveTemplate}`;
+  });
 }
 
 function tryParseFragmentIndent(
@@ -388,15 +404,20 @@ function consumeFenceBlock(queue: string[]): {
   if (queue.length === 0) return { closed: false, lines: [] };
   const opening = queue.shift()!;
   const openMatch = CODE_BLOCK_START.exec(opening);
-  if (openMatch === null || openMatch[1] === undefined) {
+  const openingToken = openMatch?.groups?.token;
+  if (openingToken === undefined) {
     return { closed: false, lines: [opening] };
   }
-  const openKind = fenceKind(openMatch[1]);
+  const openKind = fenceKind(openingToken);
   const inner: string[] = [];
   while (queue.length > 0) {
     const line = queue[0]!;
     const em = CODE_BLOCK_END.exec(line);
-    if (em?.[1] && fenceKind(em[1]) === openKind) {
+    const closingToken = em?.groups?.token;
+    if (
+      closingToken !== undefined &&
+      isMatchingFence(openingToken, closingToken, openKind)
+    ) {
       queue.shift();
       return { closed: true, lines: [opening, ...inner, line] };
     }
@@ -518,7 +539,7 @@ export function injectMarkdown(
 
     const [opening, ...mid] = fb.lines;
     const openMatch = CODE_BLOCK_START.exec(opening);
-    if (openMatch === null || openMatch[1] === undefined) {
+    if (openMatch?.groups?.token === undefined) {
       err(
         `code block should immediately follow - "${relPath}"\n not: ${opening}`,
       );
@@ -591,6 +612,7 @@ export function injectMarkdown(
       joined = appReplacePipeline(joined);
     }
     working = dropLeadingBlankLines(dropTrailingBlankLines(joined.split('\n')));
+    working = maxUnindent(working);
 
     const parsedIndent = tryParseFragmentIndent(
       fragmentArgs.indentByRaw,
@@ -620,7 +642,14 @@ export function injectMarkdown(
   while (lines.length > 0) {
     const line = lines.shift()!;
     out.push(line);
-    if (!line.includes('<?code-excerpt')) continue;
+    if (!line.includes('<?code-excerpt')) {
+      if (MALFORMED_PI_SPACE_AFTER_XML_OPEN.test(line)) {
+        warn(
+          'processing instruction ignored: XML processing instructions must start with "<?code-excerpt" (no space after "<?")',
+        );
+      }
+      continue;
+    }
 
     const match = PROC_INSTR_RE.exec(line);
     if (match === null || match.groups === undefined) {

--- a/test/dedent.test.ts
+++ b/test/dedent.test.ts
@@ -1,18 +1,18 @@
-/** @file Unit tests for `dedent` — @see `./helpers/dedent.ts`. */
+/** @file Unit tests for `dedent` helpers — @see `./helpers/dedent.ts`. */
 
 import { describe, expect, it } from 'vitest';
-import { dedent } from './helpers/dedent.js';
+import dedent, { dedent0, dedent2, dedentMax } from './helpers/dedent.js';
 
-describe('dedent', () => {
+describe('dedentMax', () => {
   it('strips the first character when it is a newline', () => {
-    expect(dedent`\na`).toBe('a');
-    expect(dedent`
+    expect(dedentMax`\na`).toBe('a');
+    expect(dedentMax`
       a`).toBe('a');
   });
 
   it('removes common leading indentation from non-blank lines', () => {
     expect(
-      dedent`
+      dedentMax`
         alpha
         beta
       `,
@@ -21,7 +21,7 @@ describe('dedent', () => {
 
   it('drops trailing whitespace-only lines', () => {
     expect(
-      dedent`
+      dedentMax`
         x
         
       `,
@@ -30,7 +30,7 @@ describe('dedent', () => {
 
   it('does not use blank lines for minimum-indent calculation', () => {
     expect(
-      dedent`
+      dedentMax`
         a
 
         b
@@ -39,9 +39,9 @@ describe('dedent', () => {
   });
 
   it('leaves lines unchanged when minimum indent is 0', () => {
-    expect(dedent`no-indent`).toBe('no-indent');
+    expect(dedentMax`no-indent`).toBe('no-indent');
     expect(
-      dedent`
+      dedentMax`
 mixed
   indented`,
     ).toBe('mixed\n  indented');
@@ -49,9 +49,9 @@ mixed
 
   it('interpolates values', () => {
     const n = 2;
-    expect(dedent`line ${n}`).toBe('line 2');
+    expect(dedentMax`line ${n}`).toBe('line 2');
     expect(
-      dedent`
+      dedentMax`
         ${'x'}
         y
       `,
@@ -59,16 +59,122 @@ mixed
   });
 
   it('returns empty string for empty or whitespace-only template', () => {
-    expect(dedent``).toBe('');
-    expect(dedent`\n`).toBe('');
+    expect(dedentMax``).toBe('');
+    expect(dedentMax`\n`).toBe('');
   });
 
   it('preserves leading spaces when they exceed common indent', () => {
     expect(
-      dedent`
+      dedentMax`
         outer
           inner
       `,
     ).toBe('outer\n  inner');
+  });
+});
+
+describe('dedent0', () => {
+  it('strips the first character when it is a newline', () => {
+    expect(dedent0`\na`).toBe('a');
+  });
+
+  it('uses the closing line indentation as the trim amount', () => {
+    expect(
+      dedent0`
+          alpha
+          beta
+      `,
+    ).toBe('    alpha\n    beta');
+  });
+
+  it('preserves extra indentation beyond the closing line margin', () => {
+    expect(
+      dedent0`
+          outer
+            inner
+      `,
+    ).toBe('    outer\n      inner');
+  });
+
+  it('returns blank interior lines without whitespace', () => {
+    expect(
+      dedent0`
+          a
+
+          b
+      `,
+    ).toBe('    a\n\n    b');
+  });
+
+  it('does not trim indentation when there is no trailing margin line', () => {
+    expect(dedent0`no-indent`).toBe('no-indent');
+    expect(
+      dedent0`
+mixed
+  indented`,
+    ).toBe('mixed\n  indented');
+  });
+
+  it('interpolates values', () => {
+    const n = 2;
+    expect(dedent0`line ${n}`).toBe('line 2');
+  });
+
+  it('returns empty string for empty or whitespace-only template', () => {
+    expect(dedent0``).toBe('');
+    expect(dedent0`\n`).toBe('');
+  });
+});
+
+describe('dedent', () => {
+  it('is the default export for dedent2', () => {
+    expect(dedent).toBe(dedent2);
+  });
+
+  it('strips two more spaces than dedent0 on non-blank lines', () => {
+    expect(
+      dedent`
+          alpha
+          beta
+      `,
+    ).toBe('  alpha\n  beta');
+  });
+
+  it('preserves extra indentation beyond the additional two-space trim', () => {
+    expect(
+      dedent`
+          outer
+            inner
+      `,
+    ).toBe('  outer\n    inner');
+  });
+
+  it('returns blank interior lines without whitespace', () => {
+    expect(
+      dedent`
+          a
+
+          b
+      `,
+    ).toBe('  a\n\n  b');
+  });
+
+  it('does not trim indentation when there is no trailing margin line', () => {
+    expect(dedent`no-indent`).toBe('no-indent');
+    expect(
+      dedent`
+mixed
+  indented`,
+    ).toBe('mixed\nindented');
+  });
+
+  it('interpolates values', () => {
+    const n = 2;
+    expect(dedent`line ${n}`).toBe('line 2');
+  });
+
+  it('returns empty string for empty or whitespace-only template', () => {
+    expect(dedent``).toBe('');
+    expect(dedent`\n`).toBe('');
   });
 });

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -7,7 +7,7 @@ import {
   getExcerptRegionLines,
   maxUnindent,
 } from '../src/extract.js';
-import { dedent } from './helpers/dedent.js';
+import dedent from './helpers/dedent.js';
 
 const uri = 'foo';
 
@@ -370,17 +370,17 @@ describe('extract', () => {
       );
     });
 
-    it('plaster indentation taken from the #enddocregion directive', () => {
-      // Content lines have 0 indent; #enddocregion has 2-space indent.
-      // maxUnindent sees min=0 (from content lines) so plaster stays '  ···'.
+    it('plaster indentation taken from the reopening #docregion directive', () => {
+      // Content lines have 0 indent; the reopened #docregion has 2-space indent.
+      // The plaster line should inherit that indentation.
       const content = dedent`
         #docregion a
         abc
-          #enddocregion a
+        #enddocregion a
         def
-        #docregion a
+          #docregion a
         ghi
-          #enddocregion a
+        #enddocregion a
       `;
       const result = extractExcerpts(uri, content);
       expect(result.get('a')).toEqual(['abc', `  ${DEFAULT_PLASTER}`, 'ghi']);

--- a/test/helpers/dedent.ts
+++ b/test/helpers/dedent.ts
@@ -1,19 +1,39 @@
+/** Tagged template helpers for de-indenting strings.
+ *
+ * Naming is as follows:
+ */
+
+/**
+ * Tagged template helper: interpolates strings and values, then strips the
+ * leading newline, removes the common indentation of all non-blank lines, and
+ * removes trailing blank lines.
+ */
+
+function interpolate(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string[] {
+  let raw = strings[0] ?? '';
+  for (let i = 0; i < values.length; i++) {
+    raw += String(values[i]) + (strings[i + 1] ?? '');
+  }
+  const noLeading = raw.startsWith('\n') ? raw.slice(1) : raw;
+  return noLeading.split('\n');
+}
+
 /**
  * Tagged template helper: strips the leading newline, removes the common
  * indentation of all non-blank lines, and removes trailing blank lines.
  * Allows multi-line test content to be indented naturally in source, mirroring
  * the Dart triple-quoted string style.
  */
-export function dedent(
+export function dedentMax(
   strings: TemplateStringsArray,
   ...values: unknown[]
 ): string {
-  let raw = strings[0] ?? '';
-  for (let i = 0; i < values.length; i++)
-    raw += String(values[i]) + (strings[i + 1] ?? '');
-  const noLeading = raw.startsWith('\n') ? raw.slice(1) : raw;
-  const lines = noLeading.split('\n');
-  while (lines.length > 0 && /^\s*$/.test(lines[lines.length - 1])) lines.pop();
+  const lines = interpolate(strings, ...values);
+  while (lines.length > 0 && /^\s*$/.test(lines[lines.length - 1]!))
+    lines.pop();
   let minIndent = Number.POSITIVE_INFINITY;
   for (const l of lines) {
     if (l.trim() !== '') {
@@ -25,3 +45,56 @@ export function dedent(
     return lines.join('\n');
   return lines.map((l) => l.slice(minIndent)).join('\n');
 }
+
+/**
+ * Tagged template helper: strips the leading newline, then uses the trailing
+ * whitespace-only line's indentation as the amount to trim from each content
+ * line. This preserves intentional extra indentation beyond the closing
+ * template line's margin.
+ */
+export function dedent0(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string {
+  const lines = interpolate(strings, ...values);
+  if (lines.length === 0) return '';
+
+  let trimIndent = '';
+  const lastLine = lines[lines.length - 1] ?? '';
+  if (/^\s*$/.test(lastLine)) {
+    trimIndent = lastLine;
+    lines.pop();
+  }
+
+  while (lines.length > 0 && /^\s*$/.test(lines[lines.length - 1]!)) {
+    lines.pop();
+  }
+  if (lines.length === 0) return '';
+  if (trimIndent === '') return lines.join('\n');
+
+  return lines
+    .map((line) => {
+      if (line.trim() === '') return '';
+      return line.startsWith(trimIndent) ? line.slice(trimIndent.length) : line;
+    })
+    .join('\n');
+}
+
+/**
+ * Tagged template helper: behaves like {@link dedent0}, then removes two more
+ * leading spaces from each non-blank line when present.
+ */
+export function dedent2(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string {
+  return dedent0(strings, ...values)
+    .split('\n')
+    .map((line) => {
+      if (line.trim() === '') return '';
+      return line.startsWith('  ') ? line.slice(2) : line;
+    })
+    .join('\n');
+}
+
+export default dedent2;

--- a/test/helpers/excerptYaml.test.ts
+++ b/test/helpers/excerptYaml.test.ts
@@ -4,7 +4,7 @@ import {
   readExcerptYamlResultSync,
   stripExcerptYamlBorder,
 } from '../../src/helpers/excerptYaml.js';
-import { dedent } from './dedent.js';
+import dedent from './dedent.js';
 import { readExcerptYamlSync } from './excerptYaml.js';
 
 // This suite primarily exercises the production helper in

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -4,7 +4,7 @@
 import { expect } from 'vitest';
 import type { Directive } from '../../src/directive.js';
 
-export { dedent } from './dedent.js';
+export { default as dedent, dedent0, dedent2, dedentMax } from './dedent.js';
 export { re } from './re.js';
 
 /** Runtime check via Vitest; narrows `d` for TypeScript after the call. */

--- a/test/inject-args.test.ts
+++ b/test/inject-args.test.ts
@@ -4,7 +4,7 @@ import {
   parseFragmentArgs,
   parseNamedArgs,
 } from '../src/inject.js';
-import { dedent } from './helpers/dedent.js';
+import dedent from './helpers/dedent.js';
 
 describe('inject arg processing', () => {
   describe('parseNamedArgs', () => {

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -10,7 +10,7 @@ import {
   PROC_INSTR_RE,
   type MarkdownInjectContext,
 } from '../src/inject.js';
-import { dedent } from './helpers/dedent.js';
+import dedent from './helpers/dedent.js';
 
 function ctx(files: Record<string, string>, base = ''): MarkdownInjectContext {
   return {
@@ -67,6 +67,11 @@ describe('inject', () => {
       const m = '<?code-excerpt "a.dart"?>   \t'.match(PROC_INSTR_RE);
       expect(m?.groups?.unnamed).toBe('a.dart');
     });
+
+    it('allows optional whitespace before the closing ?>', () => {
+      const m = '<?code-excerpt "a.dart" ?>'.match(PROC_INSTR_RE);
+      expect(m?.groups?.unnamed).toBe('a.dart');
+    });
   });
 
   describe('injectMarkdown', () => {
@@ -119,6 +124,30 @@ describe('inject', () => {
       `);
     });
 
+    it('injects through a tilde fence longer than triple tildes', () => {
+      const src = dedent`
+        // #docregion
+        tilde-body
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "tilde.dart"?>
+
+        ~~~~dart
+        old
+        ~~~~
+
+      `;
+      const out = injectMarkdown(md, ctx({ 'tilde.dart': src }));
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "tilde.dart"?>
+
+        ~~~~dart
+        tilde-body
+        ~~~~
+      `);
+    });
+
     it('injects excerpt containing nested markdown code fences when outer fence is tilde', () => {
       // Outer `~~~` is required so inner ``` lines are not mistaken for the
       // closing fence (fence-end matching is by kind: backtick vs tilde).
@@ -151,6 +180,41 @@ describe('inject', () => {
 
         Trailing prose.
         ~~~
+      `;
+      const out = injectMarkdown(md, ctx({ 'nested-fences.md': src }));
+      expect(out).toStrictEqual(expected);
+    });
+
+    it('injects excerpt inside a fence longer than triple backticks', () => {
+      const src = dedent`
+        # Section
+
+        \`\`\`dart
+        const injected = 42;
+        \`\`\`
+
+        Trailing prose.
+      `;
+      const md = dedent`
+        <?code-excerpt "nested-fences.md"?>
+
+        \`\`\`\`markdown
+        old-placeholder
+        \`\`\`\`
+
+      `;
+      const expected = dedent`
+        <?code-excerpt "nested-fences.md"?>
+
+        \`\`\`\`markdown
+        # Section
+
+        \`\`\`dart
+        const injected = 42;
+        \`\`\`
+
+        Trailing prose.
+        \`\`\`\`
       `;
       const out = injectMarkdown(md, ctx({ 'nested-fences.md': src }));
       expect(out).toStrictEqual(expected);
@@ -459,6 +523,31 @@ describe('inject', () => {
       });
       expect(onWarning).toHaveBeenCalledWith(
         expect.stringMatching(/processing instruction must be closed using/),
+      );
+    });
+
+    it('warns when a space appears after "<?" in the PI opener', () => {
+      const onWarning = vi.fn();
+      const src = dedent`
+        // #docregion
+        ok
+        // #enddocregion
+      `;
+      const md = dedent`
+        <? code-excerpt "c.dart"?>
+
+        \`\`\`
+        x
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'c.dart' ? src : null),
+        onWarning,
+      });
+      expect(out).toStrictEqual(md);
+      expect(onWarning).toHaveBeenCalledWith(
+        expect.stringContaining('must start with "<?code-excerpt"'),
       );
     });
 
@@ -869,6 +958,37 @@ describe('inject', () => {
       `);
     });
 
+    it('only substitutes standalone plaster marker lines', () => {
+      const src = dedent`
+        // #docregion
+        void f() {
+          // ···
+        }
+        // #enddocregion
+      `;
+      const md = dedent`
+        <?code-excerpt "pl-source-comment.dart"?>
+
+        \`\`\`dart
+        .
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'pl-source-comment.dart' ? src : null),
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "pl-source-comment.dart"?>
+
+        \`\`\`dart
+        void f() {
+          // ···
+        }
+        \`\`\`
+
+      `);
+    });
+
     it('uses an empty fragment plaster template', () => {
       const src = dedent`
         // #docregion
@@ -1148,6 +1268,35 @@ describe('inject', () => {
       `);
     });
 
+    it('removes shared left whitespace after transforms', () => {
+      const src = dedent`
+          info - one
+          info - two
+      `;
+      // Sanity check:
+      expect(src.match(/\s+info/)).toBeTruthy();
+      const md = dedent`
+        <?code-excerpt "analysis.txt" retain="info - "?>
+
+        \`\`\`plaintext
+        keep
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'analysis.txt' ? src : null),
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "analysis.txt" retain="info - "?>
+
+        \`\`\`plaintext
+        info - one
+        info - two
+        \`\`\`
+
+      `);
+    });
+
     it('errors when input ends after excerpt PI (no code block)', () => {
       const onError = vi.fn();
       const md = dedent`
@@ -1227,6 +1376,45 @@ describe('inject', () => {
 
         \`\`\`
         xy
+        \`\`\`
+
+      `);
+    });
+
+    it('indents plaster from the reopening #docregion directive', () => {
+      const src = dedent`
+        // #docregion sample
+        int sumUp(int a, int b, int c) {
+          return a + b + c;
+        }
+        // #enddocregion sample
+
+        void mainTest() {
+          // #docregion sample
+          int total = sumUp(1, 2, 3);
+          // #enddocregion sample
+        }
+      `;
+      const md = dedent`
+        <?code-excerpt "sample.dart (sample)"?>
+
+        \`\`\`dart
+        old
+        \`\`\`
+
+      `;
+      const out = injectMarkdown(md, {
+        readFile: (p) => (p === 'sample.dart' ? src : null),
+      });
+      expect(out).toStrictEqual(dedent`
+        <?code-excerpt "sample.dart (sample)"?>
+
+        \`\`\`dart
+        int sumUp(int a, int b, int c) {
+          return a + b + c;
+        }
+          // ···
+          int total = sumUp(1, 2, 3);
         \`\`\`
 
       `);

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -42,7 +42,7 @@ import { join, relative } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { InstructionStats } from '../src/instructionStats.js';
 import { updatePaths } from '../src/update.js';
-import { dedent } from './helpers/dedent.js';
+import dedent from './helpers/dedent.js';
 
 /** Expected `instructionStats` when no set/fragment directives were parsed. */
 const ZERO_STATS: InstructionStats = { set: 0, fragment: 0 };

--- a/transform-pi-semantics-plan.md
+++ b/transform-pi-semantics-plan.md
@@ -7,8 +7,8 @@
 - Steps 0 through 5 landed and are now the repo's current behavior.
 - The intended fragment PI semantic transition is complete for the repo-owned
   spec, code, and tests.
-- Remaining skipped legacy parity cases in `test/updater-goldens.test.ts` are
-  no longer tracked as part of this transition; treat them as separate fixture /
+- Remaining skipped legacy parity cases in `test/updater-goldens.test.ts` are no
+  longer tracked as part of this transition; treat them as separate fixture /
   parity cleanup under [`docs/plan.md`](docs/plan.md).
 - The `inject.ts` refactor note below is now optional later cleanup, not a
   required completion step for this transition.


### PR DESCRIPTION
- Adds a reusable site-www integration harness and npm entrypoint.
- Tightens PI parsing, fence matching, plaster handling, and excerpt indentation behavior.
- Refines test dedent helpers and extends regression coverage for inject and extract.