### PR TITLE
test: Angular escaping CLI integration and updatePaths warnings

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -87,7 +87,7 @@ B. [ ] Optional follow-up items:
        before processing (same `.md` once per run).
 2. [x] **Invalid `--exclude` patterns**: CLI compiles patterns with a friendly
        `error:` line on stderr and exit code 1 (see `src/excludePatterns.ts`).
-3. [ ] **`--no-escape-ng-interpolation`**: the CLI relies on Commander’s
+3. [x] **`--no-escape-ng-interpolation`**: the CLI relies on Commander’s
        handling of negated boolean flags; behavior must stay aligned with
        `injectMarkdown` (`escapeNgInterpolation !== false` means escape).
 
@@ -95,7 +95,7 @@ C. [ ] Test gaps:
 
 1. [x] CLI integration tests in `test/cli.integration.test.ts` (`--help`,
        invalid `--exclude`, `--fail-on-update` with `--dry-run`).
-2. [ ] `updatePaths`: assert `log` is called for expected lines; assert
+2. [x] `updatePaths`: assert `log` is called for expected lines; assert
        `warnings` in `UpdateResult` when `onWarning` fires.
 3. [x] `updatePaths`: duplicate / overlapping roots (dedupe; see
        `test/update.test.ts`).

--- a/test/README.md
+++ b/test/README.md
@@ -86,12 +86,13 @@ Scenario coverage:
 
 ### Related behavior (outside the fragment table)
 
-| Topic                                   | Where                                  |
-| --------------------------------------- | -------------------------------------- |
-| Set `path-base` / `replace` / `plaster` | `inject.test.ts`, goldens              |
-| `globalReplace` (CLI-style)             | `inject.test.ts`, golden `replace.md`  |
-| Unsupported `diff-with`                 | `inject.test.ts` (error path)          |
-| Liquid `{% prettify %}` fences          | `inject.test.ts`, golden `prettify.md` |
+| Topic                                   | Where                                      |
+| --------------------------------------- | ------------------------------------------ |
+| Set `path-base` / `replace` / `plaster` | `inject.test.ts`, goldens                  |
+| `globalReplace` (CLI-style)             | `inject.test.ts`, golden `replace.md`      |
+| Angular interpolation escaping          | updater fixtures, goldens, CLI integration |
+| Unsupported `diff-with`                 | `inject.test.ts` (error path)              |
+| Liquid `{% prettify %}` fences          | `inject.test.ts`, golden `prettify.md`     |
 
 ## Updater test layers
 

--- a/test/cli.integration.test.ts
+++ b/test/cli.integration.test.ts
@@ -152,4 +152,61 @@ describe('CLI (integration)', () => {
     );
     expect(readFileSync(mdPath, 'utf8')).toBe(md);
   });
+
+  describe('Angular interpolation escaping', () => {
+    function writeNgFixture(): {
+      docs: string;
+      md: string;
+      mdPath: string;
+      src: string;
+    } {
+      const work = useWorkDir();
+      const src = join(work, 'src');
+      const docs = join(work, 'docs');
+      mkdirSync(src, { recursive: true });
+      mkdirSync(docs, { recursive: true });
+      writeFileSync(
+        join(src, 'a.dart'),
+        dedent`
+          // #docregion
+          print('{{value}}');
+          // #enddocregion
+        `,
+        'utf8',
+      );
+      const md = dedent`
+        <?code-excerpt "a.dart"?>
+
+        \`\`\`dart
+        OLD
+        \`\`\`
+      `;
+      const mdPath = join(docs, 'page.md');
+      writeFileSync(mdPath, md, 'utf8');
+      return { docs, md, mdPath, src };
+    }
+
+    it('escapes Angular interpolation by default', async () => {
+      const { docs, mdPath, src } = writeNgFixture();
+
+      const result = await runCli(['-p', src, docs]);
+
+      expect(result.status, 'exit code').toBe(0);
+      expect(readFileSync(mdPath, 'utf8')).toContain("print('{!{value}!}');");
+    });
+
+    it('disables Angular interpolation escaping under --no-escape-ng-interpolation', async () => {
+      const { docs, mdPath, src } = writeNgFixture();
+
+      const result = await runCli([
+        '-p',
+        src,
+        '--no-escape-ng-interpolation',
+        docs,
+      ]);
+
+      expect(result.status, 'exit code').toBe(0);
+      expect(readFileSync(mdPath, 'utf8')).toContain("print('{{value}}');");
+    });
+  });
 });

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -652,4 +652,56 @@ describe('updatePaths', () => {
     expect(updated).toContain('world');
     expect(updated).not.toContain('hello');
   });
+
+  it('records warnings and logs warning plus update lines', async () => {
+    const { src, docs } = useTmpSrcDocs();
+
+    writeFixture(
+      src,
+      'lib/warn.dart',
+      dedent`
+        // #docregion focus
+        // #docregion focus
+        const k = 42;
+        // #enddocregion focus
+      `,
+    );
+
+    writeFixture(
+      docs,
+      'page.md',
+      dedent`
+        <?code-excerpt "lib/warn.dart" region="focus"?>
+
+        \`\`\`dart
+        placeholder
+        \`\`\`
+      `,
+    );
+
+    const logs: string[] = [];
+    const result = await updatePaths([docs], {
+      pathBase: src,
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(result.errors, result.errors.join('\n')).toEqual([]);
+    expect(result.filesUpdated).toBe(1);
+    expect(result.instructionStats).toEqual(ONE_FRAGMENT);
+
+    const warn = `warning: ${join(docs, 'page.md')}: repeated start for region "focus" at lib/warn.dart:2`;
+    const updated = `updated: ${join(docs, 'page.md')}`;
+
+    expect(result.warnings).toEqual([warn]);
+    expect(logs).toEqual([warn, updated]);
+    expect(readFileSync(join(docs, 'page.md'), 'utf8')).toStrictEqual(
+      dedent`
+        <?code-excerpt "lib/warn.dart" region="focus"?>
+
+        \`\`\`dart
+        const k = 42;
+        \`\`\`
+      `,
+    );
+  });
 });


### PR DESCRIPTION
- Add CLI tests for default `{{}}` escaping vs `--no-escape-ng-interpolation`.
- Add `updatePaths` test for `warnings`, `log` order, and output on repeated `#docregion` start.
- Mark plan checkboxes; extend `test/README.md` scenario table.