### PR TITLE
Classify ignored fragment failures as warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Changed:
 - Library issue reporting now uses the shared structured
   `onIssue({ kind, message })` / `ReportedIssue` model across directive,
   extract, transform, inject, and update APIs.
+- Recoverable ignored-fragment cases now report warning issues only instead of
+  paired warning and error issues.
 
 ## [v0.1.0][] - 2026-04-13
 

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -548,7 +548,6 @@ export function injectMarkdown(
       warn(
         `fragment ignored: reached end of input before code block - "${relPath}"`,
       );
-      err(`reached end of input, expect code block - "${relPath}"`);
       return [];
     }
 
@@ -556,10 +555,7 @@ export function injectMarkdown(
     const openMatch = CODE_BLOCK_START.exec(opening);
     if (openMatch?.groups?.token === undefined) {
       warn(
-        `fragment ignored: code block should immediately follow - "${relPath}"`,
-      );
-      err(
-        `code block should immediately follow - "${relPath}"\n not: ${opening}`,
+        `fragment ignored: code block should immediately follow - "${relPath}"; not: ${opening}`,
       );
       return [opening];
     }
@@ -568,7 +564,6 @@ export function injectMarkdown(
       warn(
         `fragment ignored: unterminated markdown code block for "${relPath}"`,
       );
-      err(`unterminated markdown code block for "${relPath}"`);
       return fb.lines;
     }
 

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -589,7 +589,7 @@ describe('inject', () => {
       ]);
     });
 
-    it('errors on unterminated markdown fence and keeps original block', () => {
+    it('warns on unterminated markdown fence and keeps original block', () => {
       const onIssue = vi.fn();
       const src = dedent`
         // #docregion
@@ -607,12 +607,13 @@ describe('inject', () => {
         onIssue,
       });
       expect(out).toStrictEqual(md);
-      expect(issueMessages(onIssue, 'error')).toEqual([
+      expect(issueMessages(onIssue, 'warning')).toEqual([
         expect.stringContaining('unterminated markdown code block'),
       ]);
+      expect(issueMessages(onIssue, 'error')).toEqual([]);
     });
 
-    it('errors when code block does not immediately follow excerpt PI', () => {
+    it('warns when code block does not immediately follow excerpt PI', () => {
       const onIssue = vi.fn();
       const src = '//\n';
       const md = dedent`
@@ -629,9 +630,10 @@ describe('inject', () => {
         onIssue,
       });
       expect(out).toStrictEqual(md);
-      expect(issueMessages(onIssue, 'error')).toEqual([
+      expect(issueMessages(onIssue, 'warning')).toEqual([
         expect.stringMatching(/code block should immediately follow/s),
       ]);
+      expect(issueMessages(onIssue, 'error')).toEqual([]);
     });
 
     it('errors on set instruction with more than one argument', () => {
@@ -1448,9 +1450,7 @@ describe('inject', () => {
       expect(issueMessages(onIssue, 'warning')).toEqual([
         expect.stringContaining('reached end of input before code block'),
       ]);
-      expect(issueMessages(onIssue, 'error')).toEqual([
-        expect.stringContaining('reached end of input'),
-      ]);
+      expect(issueMessages(onIssue, 'error')).toEqual([]);
     });
 
     it('leaves comment-prefixed input unchanged when no code block follows a PI', () => {
@@ -1466,11 +1466,11 @@ describe('inject', () => {
       });
       expect(out).toStrictEqual(md);
       expect(issueMessages(onIssue, 'warning')).toEqual([
-        expect.stringContaining('code block should immediately follow'),
+        expect.stringMatching(
+          /code block should immediately follow[\s\S]*not: int x = 0;/,
+        ),
       ]);
-      expect(issueMessages(onIssue, 'error')).toEqual([
-        expect.stringContaining('code block should immediately follow'),
-      ]);
+      expect(issueMessages(onIssue, 'error')).toEqual([]);
     });
 
     it('leaves comment-prefixed input unchanged when the closing fence is missing', () => {
@@ -1489,9 +1489,7 @@ describe('inject', () => {
       expect(issueMessages(onIssue, 'warning')).toEqual([
         expect.stringContaining('unterminated markdown code block'),
       ]);
-      expect(issueMessages(onIssue, 'error')).toEqual([
-        expect.stringContaining('unterminated markdown code block'),
-      ]);
+      expect(issueMessages(onIssue, 'error')).toEqual([]);
     });
 
     it('handles liquid prettify fences like backtick fences', () => {


### PR DESCRIPTION
- Reports recoverable ignored-fragment cases as warning issues only instead of paired warning and error issues.
- Updates direct inject tests to assert the warning-only behavior and combined detail message.
- Notes the warning classification change in the developer changelog.