### PR TITLE
Document prose PI escaping workaround

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -81,7 +81,7 @@ A. [ ] **Follow-up** (site-shared updater goldens; complements Phase 3’s
 2. [ ] Add Vitest goldens aligned with [updater_test.dart][] (copy `src/` → run
        updater → compare to `expected/`).
 
-B. [ ] Optional follow-up items:
+B. [x] Optional follow-up items:
 
 1. [x] **Overlapping `paths`**: `updatePaths` dedupes collected absolute paths
        before processing (same `.md` once per run).
@@ -91,7 +91,7 @@ B. [ ] Optional follow-up items:
        handling of negated boolean flags; behavior must stay aligned with
        `injectMarkdown` (`escapeNgInterpolation !== false` means escape).
 
-C. [ ] Test gaps:
+C. [x] Test gaps:
 
 1. [x] CLI integration tests in `test/cli.integration.test.ts` (`--help`,
        invalid `--exclude`, `--fail-on-update` with `--dry-run`).
@@ -100,19 +100,10 @@ C. [ ] Test gaps:
 3. [x] `updatePaths`: duplicate / overlapping roots (dedupe; see
        `test/update.test.ts`).
 
-D. [ ] **Revisit — `<?code-excerpt` in prose (e.g. markdown tables):** Today
-`injectMarkdown` treats any line **containing** the substring `<?code-excerpt`
-as a candidate PI; if the strict full-line regex does not match and the
-line-start `PROC_INSTR_BODY` regex also does not match (e.g. the PI text appears
-**mid-line** in documentation), the tool reports **invalid processing
-instruction**. That is awkward for docs that quote the syntax literally.
-**Current workaround:** escape the opening angle bracket in prose (e.g.
-`&lt;?code-excerpt …?>`) so the raw line does not contain `<?code-excerpt`.
-**Possible later change:** only run PI parsing / errors when there is a real
-line-start PI attempt (`PROC_INSTR_BODY` matches), so mid-line mentions are left
-alone; add a regression test and optionally document `&lt;` in
-[`docs/spec.md`](spec.md) for rare line-start edge cases (aligned with XML PI
-rules).
+D. [x] **Literal `<?code-excerpt` in prose:** documented the current workaround
+in [`docs/spec.md`](spec.md#markdown-input-assumptions): escape the opening
+angle bracket as `&lt;?code-excerpt …?>` when quoting the syntax literally in
+prose.
 
 ## Phase 5b - extra behavior
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -29,6 +29,10 @@ parser. It scans lines for processing instructions and fenced blocks with
 regex-based rules. Inputs are assumed to be well-formed Markdown with processing
 instructions.
 
+When documentation needs to mention `<?code-excerpt ...?>` literally in prose,
+escape the opening angle bracket as `&lt;?code-excerpt ...?>`. Otherwise a line
+containing the raw substring `<?code-excerpt` can be treated as a PI attempt.
+
 After a fragment instruction, the next non-empty line should be an opening
 fence, and a matching close fence of the same kind should appear before the next
 excerpt block. Malformed nesting, unbalanced fences, or excerpts embedded in

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -22,10 +22,10 @@ function ctx(files: Record<string, string>, base = ''): MarkdownInjectContext {
 
 function issueMessages(
   onIssue: ReturnType<typeof vi.fn>,
-  kind: ReportedIssue['kind'],
+  kind?: ReportedIssue['kind'],
 ): string[] {
   return (onIssue.mock.calls as [ReportedIssue][])
-    .filter(([issue]) => issue.kind === kind)
+    .filter(([issue]) => (kind ? issue.kind === kind : true))
     .map(([issue]) => issue.message);
 }
 
@@ -492,6 +492,39 @@ describe('inject', () => {
       expect(issueMessages(onIssue, 'error')).toEqual([
         expect.stringContaining('invalid processing instruction'),
       ]);
+    });
+
+    it('reports invalid processing instruction for a mid-line prose mention', () => {
+      const onIssue = vi.fn();
+      const md = dedent`
+        Inlined \`<?code-excerpt "a.dart"?>\` directive syntax in prose text.
+      `;
+
+      const out = injectMarkdown(md, {
+        readFile: () => '//\n',
+        onIssue,
+      });
+
+      expect(out).toStrictEqual(md);
+      expect(issueMessages(onIssue, 'error')).toEqual([
+        expect.stringContaining('invalid processing instruction'),
+      ]);
+      expect(issueMessages(onIssue)).toHaveLength(1);
+    });
+
+    it('ignores an escaped prose mention using &lt;', () => {
+      const onIssue = vi.fn();
+      const md = dedent`
+        "Escaped" directive syntax in prose:  \`&lt;?code-excerpt "a.dart"?>\`.
+      `;
+
+      const out = injectMarkdown(md, {
+        readFile: () => '//\n',
+        onIssue,
+      });
+
+      expect(out).toStrictEqual(md);
+      expect(issueMessages(onIssue)).toHaveLength(0);
     });
 
     it('treats valueless named args as invalid processing-instruction syntax', () => {


### PR DESCRIPTION
- Documents the `&lt;?code-excerpt ...?>` prose workaround in the spec.
- Marks the related plan item done based on the documented current behavior.
- Adds direct inject regressions for raw mid-line prose mentions and the escaped `&lt;` form.