### PR TITLE
Clarify CLI dry-run summary counts

### DIFF
--- a/scripts/test-site-www.sh
+++ b/scripts/test-site-www.sh
@@ -100,4 +100,5 @@ fi
 
 cli_args+=("${path_args[@]}")
 
+set -x # Show resolved CLI invocation and arguments.
 node dist/cli.js "${cli_args[@]}"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,7 @@ program
       const { set, fragment } = result.instructionStats;
       const summary = [
         `${result.filesProcessed} file(s) processed`,
-        `${result.filesUpdated} updated`,
+        `${result.filesUpdated} ${opts.dryRun ? 'need update' : 'updated'}`,
         `${result.errors.length} error(s)`,
         `${result.warnings.length} warning(s)`,
       ].join(', ');

--- a/test/cli.integration.test.ts
+++ b/test/cli.integration.test.ts
@@ -148,7 +148,7 @@ describe('CLI (integration)', () => {
     expect(stdout).toBe('');
     expect(stderr).toMatch(/needs update:/);
     expect(stderr).toMatch(
-      /1 file\(s\) processed, 1 updated, \d+ error\(s\), \d+ warning\(s\); \d+ set directive\(s\), 1 fragment directive\(s\)/,
+      /1 file\(s\) processed, 1 need update, \d+ error\(s\), \d+ warning\(s\); \d+ set directive\(s\), 1 fragment directive\(s\)/,
     );
     expect(readFileSync(mdPath, 'utf8')).toBe(md);
   });


### PR DESCRIPTION
- Labels summary counts as "need update" when --dry-run is used instead of "updated".
- Documents intentional set -x in scripts/test-site-www.sh so the resolved CLI invocation is visible.
- Updates CLI integration expectations for the revised summary wording.